### PR TITLE
fix: failing execute test

### DIFF
--- a/tests/unit/execute_time_plugin.test.ts
+++ b/tests/unit/execute_time_plugin.test.ts
@@ -19,7 +19,8 @@ import { sleep } from "aws-wrapper-common-lib/lib/utils/utils";
 
 const mockCallable = jest.fn();
 const timeToSleepMs = 1000;
-const timeToSleepNs = timeToSleepMs * 1000000;
+const acceptableTimeMs = 995;
+const acceptableTimeNs = acceptableTimeMs * 1000000;
 
 describe("executeTimePluginTest", () => {
   it("test_executeTime", async () => {
@@ -32,11 +33,11 @@ describe("executeTimePluginTest", () => {
 
     await plugin.execute("query", mockCallable, []);
 
-    expect(ExecuteTimePlugin.getTotalExecuteTime()).toBeGreaterThan(timeToSleepNs);
+    expect(ExecuteTimePlugin.getTotalExecuteTime()).toBeGreaterThan(acceptableTimeNs);
 
     await plugin.execute("query", mockCallable, []);
 
-    expect(ExecuteTimePlugin.getTotalExecuteTime()).toBeGreaterThan(timeToSleepNs * 2);
+    expect(ExecuteTimePlugin.getTotalExecuteTime()).toBeGreaterThan(acceptableTimeNs * 2);
 
     ExecuteTimePlugin.resetExecuteTime();
     expect(ExecuteTimePlugin.getTotalExecuteTime()).toEqual(0n);


### PR DESCRIPTION
### Summary

<!--- General summary / title -->
setTimeout for sleep can end early by ~1ms (https://github.com/nodejs/node/issues/26578). This makes the tests fail when it expects 1000ms but receives 999ms. Lowering the acceptable time accounts for the sleep ending too soon.

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
