### PR TITLE
fix: use dynamic imports for plugins construction

### DIFF
--- a/common/lib/authentication/aws_secrets_manager_plugin.ts
+++ b/common/lib/authentication/aws_secrets_manager_plugin.ts
@@ -22,9 +22,7 @@ import {
 } from "@aws-sdk/client-secrets-manager";
 import { logger } from "../../logutils";
 import { AbstractConnectionPlugin } from "../abstract_connection_plugin";
-import { ConnectionPlugin } from "../connection_plugin";
 import { HostInfo } from "../host_info";
-import { ConnectionPluginFactory } from "../plugin_factory";
 import { PluginService } from "../plugin_service";
 import { AwsWrapperError } from "../utils/errors";
 import { Messages } from "../utils/messages";
@@ -173,11 +171,5 @@ export class Secret {
   constructor(username: string, password: string) {
     this.username = username;
     this.password = password;
-  }
-}
-
-export class AwsSecretsManagerPluginFactory implements ConnectionPluginFactory {
-  getInstance(pluginService: PluginService, properties: Map<string, any>): ConnectionPlugin {
-    return new AwsSecretsManagerPlugin(pluginService, new Map(properties));
   }
 }

--- a/common/lib/authentication/aws_secrets_manager_plugin_factory.ts
+++ b/common/lib/authentication/aws_secrets_manager_plugin_factory.ts
@@ -1,0 +1,34 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConnectionPluginFactory } from "../plugin_factory";
+import { PluginService } from "../plugin_service";
+import { ConnectionPlugin } from "../connection_plugin";
+import { AwsWrapperError } from "../utils/errors";
+import { Messages } from "../utils/messages";
+import { logger } from "../../logutils";
+
+export class AwsSecretsManagerPluginFactory implements ConnectionPluginFactory {
+  async getInstance(pluginService: PluginService, properties: Map<string, any>): Promise<ConnectionPlugin> {
+    try {
+      const awsSecretsManagerPlugin = await import("./aws_secrets_manager_plugin");
+      return new awsSecretsManagerPlugin.AwsSecretsManagerPlugin(pluginService, new Map(properties));
+    } catch (error: any) {
+      logger.error(error);
+      throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "AwsSecretsManagerPlugin"));
+    }
+  }
+}

--- a/common/lib/authentication/iam_authentication_plugin.ts
+++ b/common/lib/authentication/iam_authentication_plugin.ts
@@ -14,8 +14,6 @@
   limitations under the License.
 */
 
-import { ConnectionPlugin } from "../connection_plugin";
-import { ConnectionPluginFactory } from "../plugin_factory";
 import { PluginService } from "../plugin_service";
 import { RdsUtils } from "../utils/rds_utils";
 import { Messages } from "../utils/messages";
@@ -117,11 +115,5 @@ export class IamAuthenticationPlugin extends AbstractConnectionPlugin {
 
   static clearCache(): void {
     this.tokenCache.clear();
-  }
-}
-
-export class IamAuthenticationPluginFactory implements ConnectionPluginFactory {
-  getInstance(pluginService: PluginService, properties: object): ConnectionPlugin {
-    return new IamAuthenticationPlugin(pluginService);
   }
 }

--- a/common/lib/authentication/iam_authentication_plugin_factory.ts
+++ b/common/lib/authentication/iam_authentication_plugin_factory.ts
@@ -1,0 +1,34 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConnectionPluginFactory } from "../plugin_factory";
+import { PluginService } from "../plugin_service";
+import { ConnectionPlugin } from "../connection_plugin";
+import { AwsWrapperError } from "../utils/errors";
+import { Messages } from "../utils/messages";
+import { logger } from "../../logutils";
+
+export class IamAuthenticationPluginFactory implements ConnectionPluginFactory {
+  async getInstance(pluginService: PluginService, properties: object): Promise<ConnectionPlugin> {
+    try {
+      const iamAuthenticationPlugin = await import("./iam_authentication_plugin");
+      return new iamAuthenticationPlugin.IamAuthenticationPlugin(pluginService);
+    } catch (error: any) {
+      logger.error(error);
+      throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "IamAuthenticationPlugin"));
+    }
+  }
+}

--- a/common/lib/aws_client.ts
+++ b/common/lib/aws_client.ts
@@ -70,7 +70,12 @@ export abstract class AwsClient extends EventEmitter {
     this.pluginService.setCurrentHostInfo(new HostInfo(host, port));
   }
 
+  private async setup() {
+    await this.pluginManager.init();
+  }
+
   protected async internalConnect() {
+    await this.setup();
     const hostListProvider: HostListProvider = this.pluginService
       .getDialect()
       .getHostListProvider(this.properties, this.properties.get("host"), this.pluginService);

--- a/common/lib/plugin_factory.ts
+++ b/common/lib/plugin_factory.ts
@@ -18,5 +18,5 @@ import { PluginService } from "./plugin_service";
 import { ConnectionPlugin } from "./connection_plugin";
 
 export interface ConnectionPluginFactory {
-  getInstance(pluginService: PluginService, properties: object): ConnectionPlugin;
+  getInstance(pluginService: PluginService, properties: object): Promise<ConnectionPlugin>;
 }

--- a/common/lib/plugins/connect_time_plugin.ts
+++ b/common/lib/plugins/connect_time_plugin.ts
@@ -19,9 +19,6 @@ import { logger } from "../../logutils";
 import { HostInfo } from "../host_info";
 import { getTimeInNanos } from "../utils/utils";
 import { Messages } from "../utils/messages";
-import { ConnectionPluginFactory } from "../plugin_factory";
-import { ConnectionPlugin } from "../connection_plugin";
-import { PluginService } from "../plugin_service";
 
 export class ConnectTimePlugin extends AbstractConnectionPlugin {
   private static readonly subscribedMethods: Set<string> = new Set<string>(["connect", "forceConnect"]);
@@ -69,11 +66,5 @@ export class ConnectTimePlugin extends AbstractConnectionPlugin {
 
   public static getTotalConnectTime(): bigint {
     return ConnectTimePlugin.connectTime;
-  }
-}
-
-export class ConnectTimePluginFactory implements ConnectionPluginFactory {
-  getInstance(pluginService: PluginService, properties: Map<string, any>): ConnectionPlugin {
-    return new ConnectTimePlugin();
   }
 }

--- a/common/lib/plugins/connect_time_plugin_factory.ts
+++ b/common/lib/plugins/connect_time_plugin_factory.ts
@@ -1,0 +1,34 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConnectionPluginFactory } from "../plugin_factory";
+import { PluginService } from "../plugin_service";
+import { ConnectionPlugin } from "../connection_plugin";
+import { AwsWrapperError } from "../utils/errors";
+import { Messages } from "../utils/messages";
+import { logger } from "../../logutils";
+
+export class ConnectTimePluginFactory implements ConnectionPluginFactory {
+  async getInstance(pluginService: PluginService, properties: Map<string, any>): Promise<ConnectionPlugin> {
+    try {
+      const connectTimePlugin = await import("./connect_time_plugin");
+      return new connectTimePlugin.ConnectTimePlugin();
+    } catch (error: any) {
+      logger.error(error);
+      throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "ConnectTimePlugin"));
+    }
+  }
+}

--- a/common/lib/plugins/execute_time_plugin.ts
+++ b/common/lib/plugins/execute_time_plugin.ts
@@ -16,9 +16,6 @@
 
 import { logger } from "../../logutils";
 import { AbstractConnectionPlugin } from "../abstract_connection_plugin";
-import { ConnectionPlugin } from "../connection_plugin";
-import { ConnectionPluginFactory } from "../plugin_factory";
-import { PluginService } from "../plugin_service";
 import { Messages } from "../utils/messages";
 import { getTimeInNanos } from "../utils/utils";
 
@@ -49,11 +46,5 @@ export class ExecuteTimePlugin extends AbstractConnectionPlugin {
 
   public static getTotalExecuteTime(): bigint {
     return ExecuteTimePlugin.executeTime;
-  }
-}
-
-export class ExecuteTimePluginFactory implements ConnectionPluginFactory {
-  getInstance(pluginService: PluginService, properties: Map<string, any>): ConnectionPlugin {
-    return new ExecuteTimePlugin();
   }
 }

--- a/common/lib/plugins/execute_time_plugin_factory.ts
+++ b/common/lib/plugins/execute_time_plugin_factory.ts
@@ -1,0 +1,34 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConnectionPluginFactory } from "../plugin_factory";
+import { PluginService } from "../plugin_service";
+import { ConnectionPlugin } from "../connection_plugin";
+import { AwsWrapperError } from "../utils/errors";
+import { Messages } from "../utils/messages";
+import { logger } from "../../logutils";
+
+export class ExecuteTimePluginFactory implements ConnectionPluginFactory {
+  async getInstance(pluginService: PluginService, properties: Map<string, any>): Promise<ConnectionPlugin> {
+    try {
+      const executeTimePlugin = await import("./execute_time_plugin");
+      return new executeTimePlugin.ExecuteTimePlugin();
+    } catch (error: any) {
+      logger.error(error);
+      throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "ExecuteTimePlugin"));
+    }
+  }
+}

--- a/common/lib/plugins/failover/failover_plugin.ts
+++ b/common/lib/plugins/failover/failover_plugin.ts
@@ -530,9 +530,3 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
     return false;
   }
 }
-
-export class FailoverPluginFactory implements ConnectionPluginFactory {
-  getInstance(pluginService: PluginService, properties: Map<string, any>): ConnectionPlugin {
-    return new FailoverPlugin(pluginService, properties, new RdsUtils());
-  }
-}

--- a/common/lib/plugins/failover/failover_plugin_factory.ts
+++ b/common/lib/plugins/failover/failover_plugin_factory.ts
@@ -1,0 +1,35 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConnectionPluginFactory } from "../../plugin_factory";
+import { PluginService } from "../../plugin_service";
+import { ConnectionPlugin } from "../../connection_plugin";
+import { RdsUtils } from "../../utils/rds_utils";
+import { logger } from "../../../logutils";
+import { AwsWrapperError } from "../../utils/errors";
+import { Messages } from "../../utils/messages";
+
+export class FailoverPluginFactory implements ConnectionPluginFactory {
+  async getInstance(pluginService: PluginService, properties: Map<string, any>): Promise<ConnectionPlugin> {
+    try {
+      const failoverPlugin = await import("./failover_plugin");
+      return new failoverPlugin.FailoverPlugin(pluginService, properties, new RdsUtils());
+    } catch (error: any) {
+      logger.error(error);
+      throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "FailoverPlugin"));
+    }
+  }
+}

--- a/common/lib/plugins/federated_auth/federated_auth_plugin.ts
+++ b/common/lib/plugins/federated_auth/federated_auth_plugin.ts
@@ -23,10 +23,7 @@ import { WrapperProperties } from "../../wrapper_property";
 import { logger } from "../../../logutils";
 import { AwsWrapperError } from "../../utils/errors";
 import { Messages } from "../../utils/messages";
-import { ConnectionPlugin } from "../../connection_plugin";
-import { AdfsCredentialsProviderFactory } from "./adfs_credentials_provider_factory";
 import { CredentialsProviderFactory } from "./credentials_provider_factory";
-import { ConnectionPluginFactory } from "../../plugin_factory";
 
 export class FederatedAuthPlugin extends AbstractConnectionPlugin {
   protected static readonly tokenCache = new Map<string, TokenInfo>();
@@ -117,15 +114,5 @@ export class FederatedAuthPlugin extends AbstractConnectionPlugin {
 
   public static clearCache(): void {
     this.tokenCache.clear();
-  }
-}
-
-export class FederatedAuthPluginFactory implements ConnectionPluginFactory {
-  getInstance(pluginService: PluginService, properties: Map<string, any>): ConnectionPlugin {
-    return new FederatedAuthPlugin(pluginService, this.getCredentialsProviderFactory(properties));
-  }
-
-  private getCredentialsProviderFactory(properties: Map<string, any>): CredentialsProviderFactory {
-    return new AdfsCredentialsProviderFactory();
   }
 }

--- a/common/lib/plugins/federated_auth/federated_auth_plugin_factory.ts
+++ b/common/lib/plugins/federated_auth/federated_auth_plugin_factory.ts
@@ -1,0 +1,37 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConnectionPluginFactory } from "../../plugin_factory";
+import { PluginService } from "../../plugin_service";
+import { ConnectionPlugin } from "../../connection_plugin";
+import { logger } from "../../../logutils";
+import { AwsWrapperError } from "../../utils/errors";
+import { Messages } from "../../utils/messages";
+
+export class FederatedAuthPluginFactory implements ConnectionPluginFactory {
+  async getInstance(pluginService: PluginService, properties: Map<string, any>): Promise<ConnectionPlugin> {
+    try {
+      const federatedAuthPluginImport = await import("./federated_auth_plugin");
+      const adfsCredentialsProviderFactoryImport = await import("./adfs_credentials_provider_factory");
+
+      const adfsCredentialsProviderFactory = new adfsCredentialsProviderFactoryImport.AdfsCredentialsProviderFactory();
+      return new federatedAuthPluginImport.FederatedAuthPlugin(pluginService, adfsCredentialsProviderFactory);
+    } catch (error: any) {
+      logger.error(error);
+      throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "FederatedAuthPlugin"));
+    }
+  }
+}

--- a/common/lib/plugins/read_write_splitting_plugin.ts
+++ b/common/lib/plugins/read_write_splitting_plugin.ts
@@ -26,8 +26,6 @@ import { Messages } from "../utils/messages";
 import { logger } from "../../logutils";
 import { AwsWrapperError, FailoverError } from "../utils/errors";
 import { HostRole } from "../host_role";
-import { ConnectionPluginFactory } from "../plugin_factory";
-import { ConnectionPlugin } from "../connection_plugin";
 import { SqlMethodUtils } from "../utils/sql_method_utils";
 
 export class ReadWriteSplittingPlugin extends AbstractConnectionPlugin {
@@ -386,11 +384,5 @@ export class ReadWriteSplittingPlugin extends AbstractConnectionPlugin {
   private logAndThrowError(message: string) {
     logger.error(message);
     throw new AwsWrapperError(message);
-  }
-}
-
-export class ReadWriteSplittingPluginFactory implements ConnectionPluginFactory {
-  getInstance(pluginService: PluginService, properties: Map<string, any>): ConnectionPlugin {
-    return new ReadWriteSplittingPlugin(pluginService, properties);
   }
 }

--- a/common/lib/plugins/read_write_splitting_plugin_factory.ts
+++ b/common/lib/plugins/read_write_splitting_plugin_factory.ts
@@ -1,0 +1,34 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConnectionPluginFactory } from "../plugin_factory";
+import { PluginService } from "../plugin_service";
+import { ConnectionPlugin } from "../connection_plugin";
+import { logger } from "../../logutils";
+import { AwsWrapperError } from "../utils/errors";
+import { Messages } from "../utils/messages";
+
+export class ReadWriteSplittingPluginFactory implements ConnectionPluginFactory {
+  async getInstance(pluginService: PluginService, properties: Map<string, any>): Promise<ConnectionPlugin> {
+    try {
+      const readWriteSplittingPlugin = await import("./read_write_splitting_plugin");
+      return new readWriteSplittingPlugin.ReadWriteSplittingPlugin(pluginService, properties);
+    } catch (error: any) {
+      logger.error(error);
+      throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "readWriteSplittingPlugin"));
+    }
+  }
+}

--- a/common/lib/plugins/stale_dns/stale_dns_plugin.ts
+++ b/common/lib/plugins/stale_dns/stale_dns_plugin.ts
@@ -21,8 +21,6 @@ import { StaleDnsHelper } from "./stale_dns_helper";
 import { HostInfo } from "../../host_info";
 import { HostChangeOptions } from "../../host_change_options";
 import { AwsWrapperError } from "../../utils/errors";
-import { ConnectionPluginFactory } from "../../plugin_factory";
-import { ConnectionPlugin } from "../../connection_plugin";
 
 export class StaleDnsPlugin extends AbstractConnectionPlugin {
   private static readonly subscribedMethods: Set<string> = new Set<string>(["initHostProvider", "connect", "forceConnect", "notifyHostListChanged"]);
@@ -85,11 +83,5 @@ export class StaleDnsPlugin extends AbstractConnectionPlugin {
 
   override notifyHostListChanged(changes: Map<string, Set<HostChangeOptions>>): void {
     this.staleDnsHelper.notifyHostListChanged(changes);
-  }
-}
-
-export class StaleDnsPluginFactory implements ConnectionPluginFactory {
-  getInstance(pluginService: PluginService, properties: Map<string, any>): ConnectionPlugin {
-    return new StaleDnsPlugin(pluginService, properties);
   }
 }

--- a/common/lib/plugins/stale_dns/stale_dns_plugin_factory.ts
+++ b/common/lib/plugins/stale_dns/stale_dns_plugin_factory.ts
@@ -1,0 +1,34 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConnectionPluginFactory } from "../../plugin_factory";
+import { PluginService } from "../../plugin_service";
+import { ConnectionPlugin } from "../../connection_plugin";
+import { AwsWrapperError } from "../../utils/errors";
+import { Messages } from "../../utils/messages";
+import { logger } from "../../../logutils";
+
+export class StaleDnsPluginFactory implements ConnectionPluginFactory {
+  async getInstance(pluginService: PluginService, properties: Map<string, any>): Promise<ConnectionPlugin> {
+    try {
+      const staleDnsPlugin = await import("./stale_dns_plugin");
+      return new staleDnsPlugin.StaleDnsPlugin(pluginService, properties);
+    } catch (error: any) {
+      logger.error(error);
+      throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "StaleDnsPlugin"));
+    }
+  }
+}

--- a/common/lib/utils/locales/en.json
+++ b/common/lib/utils/locales/en.json
@@ -3,6 +3,7 @@
   "PluginManager.PipelineNone": "A pipeline was requested but the created pipeline evaluated to None.",
   "ConnectionProvider.unsupportedHostSelectorStrategy": "Unsupported host selection strategy '%s' specified for this connection provider '%s'. Please visit the documentation for all supported strategies.",
   "ConnectionProvider.unsupportedHostInfoSelectorStrategy": "Unsupported host selection strategy '%s' specified for this connection provider '%s'. Please visit the documentation for all supported strategies.",
+  "ConnectionPluginChainBuilder.errorImportingPlugin": "The plugin could not be imported. Please ensure the required dependencies have been installed. Plugin: '%s'",
   "DialectManager.unknownDialectCode": "Unknown dialect code: '%s'.",
   "DialectManager.getDialectError": "Was not able to get a database dialect.",
   "DefaultPlugin.executingMethod": "Executing method: %s",

--- a/tests/unit/connection_plugin_chain_builder.test.ts
+++ b/tests/unit/connection_plugin_chain_builder.test.ts
@@ -37,7 +37,7 @@ describe("testConnectionPluginChainBuilder", () => {
     const props = new Map();
     props.set(WrapperProperties.PLUGINS.name, plugins);
 
-    const result = builder.getPlugins(mockPluginService, props, mockDefaultConnProvider, mockEffectiveConnProvider);
+    const result = await builder.getPlugins(mockPluginService, props, mockDefaultConnProvider, mockEffectiveConnProvider);
 
     expect(result.length).toBe(4);
     expect(result[0]).toBeInstanceOf(StaleDnsPlugin);
@@ -52,7 +52,7 @@ describe("testConnectionPluginChainBuilder", () => {
     props.set(WrapperProperties.PLUGINS.name, "iam,staleDns,failover");
     props.set(WrapperProperties.AUTO_SORT_PLUGIN_ORDER.name, false);
 
-    const result = builder.getPlugins(mockPluginService, props, mockDefaultConnProvider, mockEffectiveConnProvider);
+    const result = await builder.getPlugins(mockPluginService, props, mockDefaultConnProvider, mockEffectiveConnProvider);
 
     expect(result.length).toBe(4);
     expect(result[0]).toBeInstanceOf(IamAuthenticationPlugin);
@@ -66,7 +66,7 @@ describe("testConnectionPluginChainBuilder", () => {
     const props = new Map();
     props.set(WrapperProperties.PLUGINS.name, "iam,executeTime,connectTime,failover");
 
-    const result = builder.getPlugins(mockPluginService, props, mockDefaultConnProvider, mockEffectiveConnProvider);
+    const result = await builder.getPlugins(mockPluginService, props, mockDefaultConnProvider, mockEffectiveConnProvider);
 
     expect(result.length).toBe(5);
     expect(result[0]).toBeInstanceOf(FailoverPlugin);

--- a/tests/unit/read_write_splitting.test.ts
+++ b/tests/unit/read_write_splitting.test.ts
@@ -23,7 +23,7 @@ import { AwsWrapperError, FailoverSuccessError } from "../../common/lib/utils/er
 import { AwsMySQLClient } from "../../mysql/lib";
 import { anything, instance, mock, reset, verify, when } from "ts-mockito";
 import { HostListProviderService } from "../../common/lib/host_list_provider_service";
-import { ReadWriteSplittingPlugin } from "../../common/lib/plugins/read_write_splitting";
+import { ReadWriteSplittingPlugin } from "../../common/lib/plugins/read_write_splitting_plugin";
 import { SimpleHostAvailabilityStrategy } from "../../common/lib/host_availability/simple_host_availability_strategy";
 import { MySQLDatabaseDialect } from "../../mysql/lib/dialect/mysql_database_dialect";
 import { HostChangeOptions } from "../../common/lib/host_change_options";


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

Users will only have the dependencies of the plugins they require. This change adds separation between plugins and their factories with dynamic imports in order to prevent errors from occurring when a user does not have a dependency required by a plugin they are not using. For example, if not using the AWS Secrets Manager plugin, the `@aws-sdk/client-secrets-manager` package should not be required.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
