### PR TITLE
chore: set log level to silly to show driver logs in integration tests

### DIFF
--- a/tests/integration/host/src/test/java/integration/host/util/ContainerHelper.java
+++ b/tests/integration/host/src/test/java/integration/host/util/ContainerHelper.java
@@ -160,6 +160,7 @@ public class ContainerHelper {
         .withFixedExposedPort(5005, 5005);
 
     return container
+        .withEnv("LOG_LEVEL", "silly")
         .withFileSystemBind("../../../pg", "/app/pg", BindMode.READ_ONLY)
         .withFileSystemBind("../../../mysql", "/app/mysql", BindMode.READ_ONLY)
         .withFileSystemBind("../../../common", "/app/common", BindMode.READ_ONLY)


### PR DESCRIPTION
### Summary

Update log level for integration tests to show driver logs in console output

### Description

The default driver log level is set to warn, therefore integration test runs don't show any useful driver logs.
Setting the log level to the lowest level to show more information.

Test run: https://github.com/aws/aws-advanced-nodejs-wrapper/actions/runs/9489728831

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
