### PR TITLE
chore: make the logging in integration tests less verbose

### DIFF
--- a/jest.integration.config.json
+++ b/jest.integration.config.json
@@ -14,6 +14,7 @@
   },
   "globalSetup": "<rootDir>/tests/integration/container/tests/setup.ts",
   "globalTeardown": "<rootDir>/tests/integration/container/tests/teardown.ts",
+  "setupFilesAfterEnv": ["<rootDir>/tests/integration/container/tests/config.ts"],
   "testEnvironment": "node",
   "reporters": ["default", "./node_modules/jest-html-reporter"]
 }

--- a/tests/integration/container/tests/config.ts
+++ b/tests/integration/container/tests/config.ts
@@ -1,0 +1,26 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { CustomConsole, LogMessage, LogType } from "@jest/console";
+
+function simpleFormatter(type: LogType, message: LogMessage): string {
+  return message
+    .split(/\n/)
+    .map((line) => "      " + line)
+    .join("\n");
+}
+
+global.console = new CustomConsole(process.stdout, process.stderr, simpleFormatter);


### PR DESCRIPTION
### Summary


Removes the redundant `at console.log` messages. E.g., from
```
        console.log
          2024-06-12T21:28:23.714Z [debug]: Executing method: query
          at Console.log (node_modules/winston/lib/winston/transports/console.js:79:23)
```
to 
```
2024-06-12T21:28:23.714Z [debug]: Executing method: query
```

### Description

Test Run: https://github.com/aws/aws-advanced-nodejs-wrapper/actions/runs/9522036081

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
