### PR TITLE
refactor: remove taskComplete flag in failover handlers

### DIFF
--- a/common/lib/plugins/failover/reader_failover_result.ts
+++ b/common/lib/plugins/failover/reader_failover_result.ts
@@ -21,11 +21,13 @@ export class ReaderFailoverResult {
   readonly newHost: HostInfo | null;
   readonly isConnected: boolean;
   readonly exception?: Error;
+  readonly taskId?: number;
 
-  constructor(client: any | null, newHost: HostInfo | null, isConnected: boolean, exception?: Error) {
+  constructor(client: any | null, newHost: HostInfo | null, isConnected: boolean, exception?: Error, taskId?: number) {
     this.client = client;
     this.newHost = newHost;
     this.isConnected = isConnected;
     this.exception = exception;
+    this.taskId = taskId;
   }
 }


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

- removes the taskComplete flag from task a and task b in the writer failover handler and uses the WriterFailoverResult taskName to identify task completion instead
- removes the taskComplete flag from the connection attempt task in the reader failover handler and adds a taskId to identify task completion instead
- these changes were made to be clearer about which task is being returned, particularly in a scenario in which both tasks have finished

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
