### PR TITLE
fix: failover not closing all clients correctly

### DIFF
--- a/common/lib/plugins/failover/failover_plugin.ts
+++ b/common/lib/plugins/failover/failover_plugin.ts
@@ -17,12 +17,9 @@
 import { AbstractConnectionPlugin } from "../../abstract_connection_plugin";
 import { uniqueId } from "lodash";
 import { logger } from "../../../logutils";
-import { performance } from "perf_hooks";
 import { HostInfo } from "../../host_info";
 import { OldConnectionSuggestionAction } from "../../old_connection_suggestion_action";
-import { ConnectionPluginFactory } from "../../plugin_factory";
 import { PluginService } from "../../plugin_service";
-import { ConnectionPlugin } from "../../connection_plugin";
 import { HostListProviderService } from "../../host_list_provider_service";
 import { ClusterAwareReaderFailoverHandler } from "./reader_failover_handler";
 import { SubscribedMethodHelper } from "../../utils/subscribed_method_helper";

--- a/common/lib/plugins/failover/writer_failover_handler.ts
+++ b/common/lib/plugins/failover/writer_failover_handler.ts
@@ -228,7 +228,7 @@ class ReconnectToWriterHandlerTask {
       Messages.get(
         "ClusterAwareWriterFailoverHandler.taskAAttemptReconnectToWriterInstance",
         this.originalWriterHost.url,
-        JSON.stringify(maskProperties(this.initialConnectionProps))
+        JSON.stringify(Object.fromEntries(maskProperties(this.initialConnectionProps)))
       )
     );
 
@@ -325,7 +325,10 @@ class WaitForNewWriterHandlerTask {
 
   async call() {
     logger.info(
-      Messages.get("ClusterAwareWriterFailoverHandler.taskBAttemptConnectionToNewWriterInstance", JSON.stringify(this.initialConnectionProps))
+      Messages.get(
+        "ClusterAwareWriterFailoverHandler.taskBAttemptConnectionToNewWriterInstance",
+        JSON.stringify(Object.fromEntries(maskProperties(this.initialConnectionProps)))
+      )
     );
 
     try {
@@ -343,8 +346,8 @@ class WaitForNewWriterHandlerTask {
       }
 
       return new WriterFailoverResult(true, true, this.currentTopology, ClusterAwareWriterFailoverHandler.WAIT_NEW_WRITER_TASK, this.currentClient);
-    } catch (error) {
-      logger.error(Messages.get("ClusterAwareWriterFailoverHandler.taskBEncounteredException", JSON.stringify(error)));
+    } catch (error: any) {
+      logger.error(Messages.get("ClusterAwareWriterFailoverHandler.taskBEncounteredException", error.message));
       throw error;
     } finally {
       logger.info(Messages.get("ClusterAwareWriterFailoverHandler.taskBFinished"));
@@ -410,8 +413,8 @@ class WaitForNewWriterHandlerTask {
             }
           }
         }
-      } catch (error) {
-        logger.info(Messages.get("ClusterAwareWriterFailoverHandler.taskBEncounteredException", JSON.stringify(error)));
+      } catch (error: any) {
+        logger.info(Messages.get("ClusterAwareWriterFailoverHandler.taskBEncounteredException", error.message));
         return false;
       }
 
@@ -462,8 +465,6 @@ class WaitForNewWriterHandlerTask {
   async closeReaderClient() {
     try {
       await this.pluginService.tryClosingTargetClient(this.currentReaderTargetClient);
-    } catch (error) {
-      // ignore
     } finally {
       this.currentReaderTargetClient = null;
       this.currentReaderHost = null;
@@ -478,6 +479,7 @@ class WaitForNewWriterHandlerTask {
     // Task A was returned.
     if (selectedTask && selectedTask === ClusterAwareWriterFailoverHandler.RECONNECT_WRITER_TASK) {
       await this.pluginService.tryClosingTargetClient(this.currentClient);
+      await this.pluginService.tryClosingTargetClient(this.currentReaderTargetClient);
     }
   }
 

--- a/tests/unit/reader_failover_handler.test.ts
+++ b/tests/unit/reader_failover_handler.test.ts
@@ -17,7 +17,6 @@
 import { HostInfo } from "../../common/lib/host_info";
 import { PluginService } from "../../common/lib/plugin_service";
 import { ClusterAwareReaderFailoverHandler } from "../../common/lib/plugins/failover/reader_failover_handler";
-import { AwsClient } from "../../common/lib/aws_client";
 import { HostAvailability } from "../../common/lib/host_availability/host_availability";
 import { HostRole } from "../../common/lib/host_role";
 import { AwsWrapperError } from "../../common/lib/utils/errors";
@@ -33,8 +32,6 @@ const defaultHosts = [host1, host2, host3, host4, host5, host6];
 const properties = new Map();
 const mockTargetClient = { client: 123 };
 
-const mockClient = mock(AwsClient);
-const mockClientInstance = instance(mockClient);
 const mockPluginService = mock(PluginService);
 
 describe("reader failover handler", () => {


### PR DESCRIPTION
### Summary

fix: failover not closing all clients correctly

### Description

- close reader target client on writer failover task b cancel
- mask logged properties in failover handlers
- change reader connection tasks to close after connection attempts instead of closing after returning a successful result
- await reader connection tasks

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
