### PR TITLE
refactor: update unit tests, fix host monitoring plugin type checks

### DIFF
--- a/tests/unit/monitor_impl.test.ts
+++ b/tests/unit/monitor_impl.test.ts
@@ -21,6 +21,7 @@ import { HostInfo } from "../../common/lib/host_info";
 import { AwsClient } from "../../common/lib/aws_client";
 import { MonitorConnectionContext } from "../../common/lib/plugins/efm/monitor_connection_context";
 import { sleep } from "../../common/lib/utils/utils";
+import { ClientWrapper } from "../../common/lib/client_wrapper";
 
 class MonitorImplTest extends MonitorImpl {
   constructor(pluginService: PluginService, hostInfo: HostInfo, properties: Map<string, any>, monitorDisposalTimeMillis: number) {
@@ -35,7 +36,12 @@ class MonitorImplTest extends MonitorImpl {
 const mockPluginService = mock(PluginService);
 const mockHostInfo = mock(HostInfo);
 const mockClient = mock(AwsClient);
-const mockTargetClient = {};
+const clientWrapper: ClientWrapper = {
+  client: undefined,
+  hostInfo: mock(HostInfo),
+  properties: new Map<string, any>()
+};
+const mockClientWrapper: ClientWrapper = mock(clientWrapper);
 
 const SHORT_INTERVAL_MILLIS = 30;
 
@@ -48,7 +54,7 @@ describe("monitor impl test", () => {
     reset(mockPluginService);
 
     when(mockPluginService.getCurrentClient()).thenReturn(instance(mockClient));
-    when(mockPluginService.forceConnect(anything(), anything())).thenReturn(mockTargetClient);
+    when(mockPluginService.forceConnect(anything(), anything())).thenResolve(mockClientWrapper);
 
     monitor = new MonitorImplTest(instance(mockPluginService), instance(mockHostInfo), properties, 0);
     monitorSpy = spy(monitor);
@@ -78,7 +84,7 @@ describe("monitor impl test", () => {
     const status2 = await monitor.checkConnectionStatus();
     expect(status2.isValid).toBe(true);
 
-    verify(mockPluginService.isClientValid(mockTargetClient)).twice();
+    verify(mockPluginService.isClientValid(mockClientWrapper)).twice();
   });
 
   it("is client healthy with error", async () => {

--- a/tests/unit/notification_pipeline.test.ts
+++ b/tests/unit/notification_pipeline.test.ts
@@ -21,6 +21,7 @@ import { PluginServiceManagerContainer } from "../../common/lib/plugin_service_m
 import { DefaultPlugin } from "../../common/lib/plugins/default_plugin";
 import { instance, mock } from "ts-mockito";
 import { PluginService } from "../../common/lib/plugin_service";
+import { DriverConnectionProvider } from "../../common/lib/driver_connection_provider";
 
 class TestPlugin extends DefaultPlugin {
   counter: number = 0;
@@ -51,8 +52,8 @@ describe("notificationPipelineTest", () => {
   let plugin: TestPlugin;
 
   beforeEach(() => {
-    pluginManager = new PluginManager(container, props);
-    plugin = new TestPlugin(instance(mockPluginService));
+    pluginManager = new PluginManager(container, props, new DriverConnectionProvider(), null);
+    plugin = new TestPlugin(instance(mockPluginService), new DriverConnectionProvider(), null);
     pluginManager["_plugins"] = [plugin];
   });
 

--- a/tests/unit/stale_dns_helper.test.ts
+++ b/tests/unit/stale_dns_helper.test.ts
@@ -24,7 +24,7 @@ import { StaleDnsHelper } from "../../common/lib/plugins/stale_dns/stale_dns_hel
 import { AwsClient } from "../../common/lib/aws_client";
 import { HostChangeOptions } from "../../common/lib/host_change_options";
 import { DatabaseDialect } from "../../common/lib/database_dialect/database_dialect";
-import { ClientWrapper } from "../../common/lib/client_wrapper"
+import { ClientWrapper } from "../../common/lib/client_wrapper";
 
 const mockPluginService: PluginService = mock(PluginService);
 const mockHostListProviderService = mock<HostListProviderService>();
@@ -44,10 +44,11 @@ const mockInitialConn = mock(AwsClient);
 const mockHostInfo = mock(HostInfo);
 const mockDialect = mock<DatabaseDialect>();
 
-const clientWrapper: ClientWrapper = { 
-  client : undefined,
-  hostInfo : mockHostInfo,
-  properties : new Map<string, any>()}
+const clientWrapper: ClientWrapper = {
+  client: undefined,
+  hostInfo: mockHostInfo,
+  properties: new Map<string, any>()
+};
 
 const mockInitialClientWrapper: ClientWrapper = mock(clientWrapper);
 const mockClientWrapper: ClientWrapper = mock(clientWrapper);
@@ -254,10 +255,10 @@ describe("test_stale_dns_helper", () => {
       mockConnectFunc
     );
 
-    expect(mockInitialConn).not.toBe(returnConn);   // TODO fix  mockInitialConn should be mockInitialClientWrapper check assumptions
+    expect(mockInitialConn).not.toBe(returnConn); // TODO fix  mockInitialConn should be mockInitialClientWrapper check assumptions
     expect(mockConnectFunc).toHaveBeenCalled();
     // verify(mockPluginService.connect(anything(), anything())).once(); //TODO fix
-    
+
     // note: it appears that the mocked version doesn't have all the values in stale_dns_helper for this case.
     // it fails the following line in common/lib/plugins/stale_dns/stale_dns_helper.ts file
     // const newProps = new Map<string, any>(props);

--- a/tests/unit/writer_failover_handler.test.ts
+++ b/tests/unit/writer_failover_handler.test.ts
@@ -43,6 +43,7 @@ const mockReaderFailover = mock(ClusterAwareReaderFailoverHandler);
 
 const mockTargetClient = { client: 123 };
 
+// TODO: re-enable tests
 describe("writer failover handler", () => {
   beforeEach(() => {
     writer.addAlias("writer-host");


### PR DESCRIPTION
### Summary

refactor: update unit tests, fix host monitoring plugin type checks

### Description

- fix incorrect type for `monitoringHostInfo` in host monitoring plugin
- fix undefined targetClient check in host monitoring plugin
- change mockTargetClient object to mockClientWrapper object in some unit tests

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
