### PR TITLE
fix: missing step during client initialization

### DIFF
--- a/common/lib/aws_client.ts
+++ b/common/lib/aws_client.ts
@@ -85,6 +85,7 @@ export abstract class AwsClient extends EventEmitter {
     const info = this.pluginService.getCurrentHostInfo();
     if (info != null) {
       await this.pluginManager.initHostProvider(info, this.properties, this.pluginService);
+      await this.pluginService.refreshHostList();
     }
   }
 

--- a/common/lib/host_list_provider/rds_host_list_provider.ts
+++ b/common/lib/host_list_provider/rds_host_list_provider.ts
@@ -161,17 +161,13 @@ export class RdsHostListProvider implements DynamicHostListProvider {
     this.init();
 
     const currentClient = targetClient ?? this.hostListProviderService.getCurrentClient().targetClient;
-    if (currentClient) {
-      const results: FetchTopologyResult = await this.getTopology(currentClient, false);
-      logger.debug(logTopology(results.hosts, results.isCachedData ? "[From cache] " : ""));
-
-      this.hostList = results.hosts;
-      return this.hostList;
-    }
-    throw new AwsWrapperError("Could not retrieve targetClient.");
+    const results: FetchTopologyResult = await this.getTopology(currentClient, false);
+    logger.debug(logTopology(results.hosts, results.isCachedData ? "[From cache] " : ""));
+    this.hostList = results.hosts;
+    return this.hostList;
   }
 
-  async getTopology(targetClient: ClientWrapper, forceUpdate: boolean): Promise<FetchTopologyResult> {
+  async getTopology(targetClient: ClientWrapper | undefined, forceUpdate: boolean): Promise<FetchTopologyResult> {
     this.init();
 
     if (!this.clusterId) {
@@ -192,8 +188,7 @@ export class RdsHostListProvider implements DynamicHostListProvider {
     const needToSuggest: boolean = !cachedHosts && this.isPrimaryClusterId === true;
     if (!cachedHosts || forceUpdate) {
       // need to re-fetch the topology.
-
-      if (!(await this.hostListProviderService.isClientValid(targetClient))) {
+      if (!targetClient || !(await this.hostListProviderService.isClientValid(targetClient))) {
         return new FetchTopologyResult(false, this.initialHostList);
       }
 


### PR DESCRIPTION
### Summary

Topology should be populated with the current host during client initialization.

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
