### PR TITLE
refactor: change any to ClientWrapper; remove unused imports

### DIFF
--- a/common/lib/host_info_builder.ts
+++ b/common/lib/host_info_builder.ts
@@ -19,7 +19,6 @@ import { HostAvailability } from "./host_availability/host_availability";
 import { HostInfo } from "./host_info";
 import { HostAvailabilityStrategy } from "./host_availability/host_availability_strategy";
 import { AwsWrapperError } from "./utils/errors";
-import { SimpleHostAvailabilityStrategy } from "./host_availability/simple_host_availability_strategy";
 
 export class HostInfoBuilder {
   private host: string;

--- a/common/lib/plugin_service.ts
+++ b/common/lib/plugin_service.ts
@@ -371,9 +371,9 @@ export class PluginService implements ErrorHandler, HostListProviderService {
   async tryClosingTargetClient(targetClient?: ClientWrapper | undefined): Promise<void> {
     // Note: This last overload is only required because of the way typescript overloads work https://www.typescriptlang.org/docs/handbook/functions.html#overloads
     if (targetClient) {
-      this.getDialect().tryClosingTargetClient(targetClient);
+      await this.getDialect().tryClosingTargetClient(targetClient);
     } else if (this._currentClient.targetClient) {
-      this.getDialect().tryClosingTargetClient(this._currentClient.targetClient);
+      await this.getDialect().tryClosingTargetClient(this._currentClient.targetClient);
     }
   }
 

--- a/common/lib/plugins/efm/monitor.ts
+++ b/common/lib/plugins/efm/monitor.ts
@@ -19,6 +19,8 @@ import { HostInfo } from "../../host_info";
 import { PluginService } from "../../plugin_service";
 import { logger } from "../../../logutils";
 import { Messages } from "../../utils/messages";
+import { ClientWrapper } from "../../client_wrapper";
+import { sleep } from "../../utils/utils";
 
 export interface Monitor {
   startMonitoring(context: MonitorConnectionContext): void;
@@ -62,7 +64,7 @@ export class MonitorImpl implements Monitor {
   private started = false;
   private stopped: boolean = false;
   private cancel: boolean = false;
-  private monitoringClient: any | null = null;
+  private monitoringClient: ClientWrapper | null = null;
   private delayMillisTimeoutId: any;
   private sleepWhenInactiveTimeoutId: any;
 
@@ -268,6 +270,8 @@ export class MonitorImpl implements Monitor {
     clearTimeout(this.delayMillisTimeoutId);
     clearTimeout(this.sleepWhenInactiveTimeoutId);
     await this.endMonitoringClient();
+    // Allow time for monitor loop to close.
+    await sleep(500);
   }
 
   async endMonitoringClient() {

--- a/common/lib/plugins/efm/monitor_connection_context.ts
+++ b/common/lib/plugins/efm/monitor_connection_context.ts
@@ -17,12 +17,13 @@
 import { Monitor } from "./monitor";
 import { logger } from "../../../logutils";
 import { Messages } from "../../utils/messages";
+import { ClientWrapper } from "../../client_wrapper";
 
 export class MonitorConnectionContext {
   readonly failureDetectionIntervalMillis: number;
   private readonly failureDetectionTimeMillis: number;
   private readonly failureDetectionCount: number;
-  readonly clientToAbort: any;
+  readonly clientToAbort: ClientWrapper;
   readonly monitor: Monitor;
 
   isActiveContext: boolean = true;
@@ -61,10 +62,10 @@ export class MonitorConnectionContext {
     }
 
     try {
-      await this.clientToAbort.end();
+      await this.clientToAbort.client.end();
     } catch (error: any) {
       // ignore
-      logger.debug(Messages.get("MonitorConnectionContext.exceptionAbortingConnection"));
+      logger.debug(Messages.get("MonitorConnectionContext.exceptionAbortingConnection", error.message));
     }
     this.abortedConnectionCounter++;
   }

--- a/common/lib/plugins/federated_auth/federated_auth_plugin.ts
+++ b/common/lib/plugins/federated_auth/federated_auth_plugin.ts
@@ -24,7 +24,6 @@ import { logger } from "../../../logutils";
 import { AwsWrapperError } from "../../utils/errors";
 import { Messages } from "../../utils/messages";
 import { CredentialsProviderFactory } from "./credentials_provider_factory";
-import { ConnectionPluginFactory } from "../../plugin_factory";
 import { SamlUtils } from "../../utils/saml_utils";
 import { ClientWrapper } from "../../client_wrapper";
 

--- a/common/lib/topology_aware_database_dialect.ts
+++ b/common/lib/topology_aware_database_dialect.ts
@@ -15,7 +15,6 @@
 */
 
 import { HostInfo } from "./host_info";
-import { AwsClient } from "./aws_client";
 import { HostListProvider } from "./host_list_provider/host_list_provider";
 import { HostRole } from "./host_role";
 import { ClientWrapper } from "./client_wrapper";

--- a/common/lib/utils/locales/en.json
+++ b/common/lib/utils/locales/en.json
@@ -111,7 +111,7 @@
   "SamlAuthPlugin.unhandledException": "Unhandled exception: '%s'",
   "HostAvailabilityStrategy.invalidMaxRetries": "Invalid value of '%s' for configuration parameter `hostAvailabilityStrategyMaxRetries`. It must be an integer greater or equal to 1.",
   "HostAvailabilityStrategy.invalidInitialBackoffTime": "Invalid value of '%s'  for configuration parameter `hostAvailabilityStrategyInitialBackoffTime`. It must be an integer greater or equal to 1.",
-  "MonitorConnectionContext.exceptionAbortingConnection": "Exception during aborting connection",
+  "MonitorConnectionContext.exceptionAbortingConnection": "Exception during aborting connection: %s.",
   "MonitorConnectionContext.hostDead": "Host %s is *dead*.",
   "MonitorConnectionContext.hostNotResponding": "Host %s is not *responding* %s",
   "MonitorConnectionContext.hostAlive": "Host %s is *alive*.",

--- a/tests/integration/container/tests/utils/test_database_info.ts
+++ b/tests/integration/container/tests/utils/test_database_info.ts
@@ -16,7 +16,6 @@
 
 import { TestInstanceInfo } from "./test_instance_info";
 import { DBInstance } from "@aws-sdk/client-rds/dist-types/models/models_0";
-import { logger } from "../../../../../common/logutils";
 
 export class TestDatabaseInfo {
   private readonly _username: string;


### PR DESCRIPTION
### Summary

refactor: change any to ClientWrapper; remove unused imports

### Description

- changes any type to ClientWrapper in monitor.ts and monitor_connection_context.ts
- adds await to tryClosingTargetClient method
- removes unused imports

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
