### PR TITLE
chore: remove github actions ip from security group after integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,6 +69,21 @@ jobs:
           AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
           NUM_INSTANCES: 5
 
+      - name: "Get Github Action IP"
+        if: always()
+        id: ip
+        uses: haythem/public-ip@v1.3
+
+      - name: "Remove Github Action IP"
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress \
+            --group-name default \
+            --protocol -1 \
+            --port -1 \
+            --cidr ${{ steps.ip.outputs.ipv4 }}/32 \
+          2>&1 > /dev/null;
+
       - name: Archive results
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Summary

chore: remove github actions ip from security group after integration tests

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
