### PR TITLE
fix: query timeout error incorrectly thrown for methods returning null or undefined

### DIFF
--- a/common/lib/utils/client_utils.ts
+++ b/common/lib/utils/client_utils.ts
@@ -16,7 +16,7 @@
 
 import { getTimeoutTask } from "./utils";
 import { Messages } from "./messages";
-import { AwsWrapperError } from "./errors";
+import { AwsWrapperError, InternalQueryTimeoutError } from "./errors";
 import { logger } from "../../logutils";
 import { WrapperProperties } from "../wrapper_property";
 
@@ -31,7 +31,7 @@ export class ClientUtils {
     return await Promise.race([timeoutTask, newPromise])
       .catch((error: any) => {
         logger.debug(error);
-        if (error instanceof AwsWrapperError) {
+        if (error instanceof InternalQueryTimeoutError) {
           throw error;
         }
         throw new AwsWrapperError(error);

--- a/common/lib/utils/errors.ts
+++ b/common/lib/utils/errors.ts
@@ -14,6 +14,8 @@
   limitations under the License.
 */
 
+import { Messages } from "./messages";
+
 export class AwsWrapperError extends Error {
   constructor(message?: string, cause?: any) {
     super(message);
@@ -35,3 +37,5 @@ export class FailoverFailedError extends FailoverError {}
 export class TransactionResolutionUnknownError extends FailoverError {}
 
 export class LoginError extends AwsWrapperError {}
+
+export class InternalQueryTimeoutError extends AwsWrapperError {}

--- a/common/lib/utils/utils.ts
+++ b/common/lib/utils/utils.ts
@@ -19,7 +19,7 @@ import { Messages } from "./messages";
 import { WrapperProperties } from "../wrapper_property";
 import { HostRole } from "../host_role";
 import { logger } from "../../logutils";
-import { AwsWrapperError } from "./errors";
+import { AwsWrapperError, InternalQueryTimeoutError } from "./errors";
 
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -28,7 +28,7 @@ export function sleep(ms: number) {
 export function getTimeoutTask(timer: any, message: string, timeoutValue: number): Promise<void> {
   return new Promise((_resolve, reject) => {
     timer.timeoutId = setTimeout(() => {
-      throw new AwsWrapperError(Messages.get("ClientUtils.queryTaskTimeout"));
+      reject(new InternalQueryTimeoutError(message));
     }, timeoutValue);
   });
 }


### PR DESCRIPTION
### Summary

Fix bug where calling `AwsMySQLClient#end()` throws `AwsWrapperError: Client query task timed out.` regardless of whether `end()` was successful or not.

Also removes the extra `AwsWrapperError` when the timeout message is thrown: `AwsWrapperError: AwsWrapperError: Client query task timed out.`

### Description

#### Repro

Run the following test, remember the update the connection variables:
```ts
  it("mysql", async () => {
    const client = new AwsMySQLClient({
      user: MYSQL_DB_USER,
      host: MYSQL_DB_HOST,
      database: MYSQL_DB_NAME,
      password: MYSQL_DB_PASSWORD,
      port: 3306
    });

    client.on("error", (error: any) => {
      console.log(error);
    });

    await client.connect();
    const res = await client.query({ sql: "select 1" });
    await client.end();
  }, 100000);
```

This will fail with the message: `AwsWrapperError: AwsWrapperError: Client query task timed out.` 

#### Root Cause
In `queryWithTimeout` in `client_utils.ts`, the method calls `Promise.race()` on the database method call and a timeout task.
When the race() finishes timeout method checks the result and if the result it undefined or null it throws the timeout error.
```ts
    return await Promise.race([timeoutTask, newPromise])
      .then((result) => {
        if (result) {
          return result;
        }
        throw new AwsWrapperError(Messages.get("ClientUtils.queryTaskTimeout"));
      })
```
This method assumes that if `result` is undefined or null then it means the timeoutTask has completed because the timeoutTask doesn't return a result.

This works for cases where the database method calls that return a value, such as the `query()` method call that returns a result set. `end()` doesn't return a result set.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
