### PR TITLE
fix: close current connection after switching to a new connection

### DIFF
--- a/common/lib/plugins/read_write_splitting_plugin.ts
+++ b/common/lib/plugins/read_write_splitting_plugin.ts
@@ -317,6 +317,9 @@ export class ReadWriteSplittingPlugin extends AbstractConnectionPlugin {
     } else if (this.writerTargetClient) {
       await this.switchCurrentTargetClientTo(this.writerTargetClient, writerHost);
     }
+    // TODO: check if reader is from internal connection pool
+    await this.closeTargetClientIfIdle(this.readerTargetClient);
+
     logger.debug(Messages.get("ReadWriteSplittingPlugin.switchedFromReaderToWriter", writerHost.url));
   }
 
@@ -342,6 +345,9 @@ export class ReadWriteSplittingPlugin extends AbstractConnectionPlugin {
         await this.initializeReaderClient(hosts);
       }
     }
+
+    // TODO: check if writer is from internal connection pool
+    await this.closeTargetClientIfIdle(this.writerTargetClient);
   }
 
   async isTargetClientUsable(targetClient: ClientWrapper | undefined): Promise<boolean> {


### PR DESCRIPTION
### Summary

When using the Read/Write Splitting plugin, triggering a connection switch would cause the application to hang after completing all business logic. This is because when switching to a new connection the existing connection does not get closed. 

This issue will be resolved once internal pool is implemented, which allows the RW plugin to track current connections before switching to the new connections, and thus allowing faster switch backs.

Since the internal connection pool logic hasn't been implemented there is no need to keep the existing connections opened at the moment. This PR closes the existing connections after switching to new connections.

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
