### PR TITLE
fix: prevent reader failover handler from accidentally closing the current client

### DIFF
--- a/common/lib/plugins/failover/reader_failover_handler.ts
+++ b/common/lib/plugins/failover/reader_failover_handler.ts
@@ -330,7 +330,7 @@ class ConnectionAttemptTask {
   }
 
   async performFinalCleanup() {
-    if (this.selectedTask !== this.taskId) {
+    if (this.selectedTask !== this.taskId && this.targetClient.host === this.newHost) {
       await this.pluginService.tryClosingTargetClient(this.targetClient);
     }
   }


### PR DESCRIPTION

### Summary

If forceConnect errors out on this line: https://github.com/aws/aws-advanced-nodejs-wrapper/blob/0eb321983b8f2783f90b2b06541c815c423febfd/common/lib/plugins/failover/reader_failover_handler.ts#L311, `this.targetClient` won't be set, `performFinalCleanup` on https://github.com/aws/aws-advanced-nodejs-wrapper/blob/0eb321983b8f2783f90b2b06541c815c423febfd/common/lib/plugins/failover/reader_failover_handler.ts#L328 should not be closing `this.targetClient` in case it points to something else.

### Description

During reader failover the driver spins up 2 async calls attempting to connect to two different readers at the same time.
If one of the async tasks succeeds the driver returns the connection from that task. Since there isn't a way to cancel an async task that has already started running, the other task will continue to run.
Both tasks attempts to connect to a different reader instance and both will try to set `this.targetClient` upon a successful connection: https://github.com/aws/aws-advanced-nodejs-wrapper/blob/0eb321983b8f2783f90b2b06541c815c423febfd/common/lib/plugins/failover/reader_failover_handler.ts#L311

Say task A successfully connects to instance A, `this.targetClient` will be set to connection A. The driver will return this new connection and exit the reader failover workflow. The application will continue running while using connection A.

Task B can't be canceled so it continues to run in the background. If task B fails during `forceConnect` then`this.targetClient` will not be set, and will still point to connection A. During the finally clause on https://github.com/aws/aws-advanced-nodejs-wrapper/blob/0eb321983b8f2783f90b2b06541c815c423febfd/common/lib/plugins/failover/reader_failover_handler.ts#L328 the driver will attempt to close `this.targetClient`, causing the rest of the application referencing this connection to fail.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
