### PR TITLE
fix: errors thrown in plugin construction may appear as a missing dependency

### DIFF
--- a/common/lib/authentication/aws_secrets_manager_plugin_factory.ts
+++ b/common/lib/authentication/aws_secrets_manager_plugin_factory.ts
@@ -27,8 +27,11 @@ export class AwsSecretsManagerPluginFactory implements ConnectionPluginFactory {
       const awsSecretsManagerPlugin = await import("./aws_secrets_manager_plugin");
       return new awsSecretsManagerPlugin.AwsSecretsManagerPlugin(pluginService, new Map(properties));
     } catch (error: any) {
-      logger.error(error);
-      throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "AwsSecretsManagerPlugin"));
+      if (error.code === "MODULE_NOT_FOUND") {
+        logger.error(error);
+        throw new AwsWrapperError(Messages.get("ConnectionPluginChainBuilder.errorImportingPlugin", "AwsSecretsManagerPlugin"));
+      }
+      throw error;      
     }
   }
 }

--- a/common/lib/host_info_builder.ts
+++ b/common/lib/host_info_builder.ts
@@ -19,6 +19,7 @@ import { HostAvailability } from "./host_availability/host_availability";
 import { HostInfo } from "./host_info";
 import { HostAvailabilityStrategy } from "./host_availability/host_availability_strategy";
 import { AwsWrapperError } from "./utils/errors";
+import { Messages } from "./utils/messages";
 
 export class HostInfoBuilder {
   private host: string;
@@ -99,7 +100,7 @@ export class HostInfoBuilder {
 
   build() {
     if (!this.host) {
-      throw new AwsWrapperError("host parameter must be set");
+      throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter"));
     }
     return new HostInfo(
       this.host,

--- a/common/lib/plugin_manager.ts
+++ b/common/lib/plugin_manager.ts
@@ -54,7 +54,7 @@ class PluginChain<T> {
 
   execute(pluginFunc: PluginFunc<T>): Promise<T> {
     if (this.chain === undefined) {
-      throw new AwsWrapperError(Messages.get("PluginManager.PipelineNone"));
+      throw new AwsWrapperError(Messages.get("PluginManager.pipelineNone"));
     }
     return this.chain(pluginFunc, this.targetFunc);
   }
@@ -113,7 +113,7 @@ export class PluginManager {
 
   async execute<T>(hostInfo: HostInfo | null, props: Map<string, any>, methodName: string, methodFunc: () => Promise<T>, options: any): Promise<T> {
     if (hostInfo == null) {
-      throw new AwsWrapperError("No host");
+      throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter"));
     }
 
     const telemetryContext = this.telemetryFactory.openTelemetryContext(methodName, TelemetryTraceLevel.NESTED);
@@ -130,7 +130,7 @@ export class PluginManager {
 
   async connect(hostInfo: HostInfo | null, props: Map<string, any>, isInitialConnection: boolean): Promise<ClientWrapper> {
     if (hostInfo == null) {
-      throw new AwsWrapperError("HostInfo was not provided.");
+      throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter"));
     }
 
     const telemetryContext = this.telemetryFactory.openTelemetryContext(PluginManager.CONNECT_METHOD, TelemetryTraceLevel.NESTED);
@@ -150,7 +150,7 @@ export class PluginManager {
 
   async forceConnect(hostInfo: HostInfo | null, props: Map<string, any>, isInitialConnection: boolean): Promise<ClientWrapper> {
     if (hostInfo == null) {
-      throw new AwsWrapperError("HostInfo was not provided.");
+      throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter"));
     }
 
     const telemetryContext = this.telemetryFactory.openTelemetryContext(PluginManager.FORCE_CONNECT_METHOD, TelemetryTraceLevel.NESTED);

--- a/common/lib/plugin_service.ts
+++ b/common/lib/plugin_service.ts
@@ -390,7 +390,7 @@ export class PluginService implements ErrorHandler, HostListProviderService {
         }
         return changes;
       }
-      throw new AwsWrapperError("HostInfo not found"); // Should not be reached
+      throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter")); // Should not be reached
     }
   }
 

--- a/common/lib/plugins/aurora_initial_connection_strategy_plugin.ts
+++ b/common/lib/plugins/aurora_initial_connection_strategy_plugin.ts
@@ -113,7 +113,7 @@ export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
 
   async getVerifiedWriterClient<T>(props: Map<string, any>, isInitialConnection: boolean, connectFunc: () => Promise<T>): Promise<any> {
     if (!this.hostListProviderService) {
-      throw new AwsWrapperError("Host list provider service not found."); // should not be reached
+      throw new AwsWrapperError(Messages.get("HostListProviderService.notFound")); // should not be reached
     }
     const retryDelayMs = WrapperProperties.OPEN_CONNECTION_RETRY_INTERVAL_MS.get(props);
 
@@ -177,7 +177,7 @@ export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
 
   async getVerifiedReaderClient<T>(props: Map<string, any>, isInitialConnection: boolean, connectFunc: () => Promise<T>): Promise<any> {
     if (!this.hostListProviderService) {
-      throw new AwsWrapperError("Host list provider service not found."); // should not be reached
+      throw new AwsWrapperError(Messages.get("HostListProviderService.notFound")); // should not be reached
     }
 
     const retryDelayMs = WrapperProperties.OPEN_CONNECTION_RETRY_INTERVAL_MS.get(props);

--- a/common/lib/plugins/federated_auth/saml_credentials_provider_factory.ts
+++ b/common/lib/plugins/federated_auth/saml_credentials_provider_factory.ts
@@ -56,7 +56,7 @@ export abstract class SamlCredentialsProviderFactory implements CredentialsProvi
 
   formatIdpEndpoint(idpEndpoint: string): string {
     // Only add "https://" if user has passed their idpEndpoint without the URL scheme.
-    if (!idpEndpoint.startsWith("https://")) {
+    if (idpEndpoint && !idpEndpoint.startsWith("https://")) {
       return `https://${idpEndpoint}`;
     }
     return idpEndpoint;

--- a/common/lib/plugins/stale_dns/stale_dns_plugin.ts
+++ b/common/lib/plugins/stale_dns/stale_dns_plugin.ts
@@ -22,6 +22,7 @@ import { HostInfo } from "../../host_info";
 import { HostChangeOptions } from "../../host_change_options";
 import { AwsWrapperError } from "../../utils/errors";
 import { ClientWrapper } from "../../client_wrapper";
+import { Messages } from "../../utils/messages";
 
 export class StaleDnsPlugin extends AbstractConnectionPlugin {
   private static readonly subscribedMethods: Set<string> = new Set<string>(["initHostProvider", "connect", "forceConnect", "notifyHostListChanged"]);
@@ -46,7 +47,7 @@ export class StaleDnsPlugin extends AbstractConnectionPlugin {
     connectFunc: () => Promise<ClientWrapper>
   ): Promise<ClientWrapper> {
     if (!this.hostListProviderService) {
-      throw new AwsWrapperError("HostListProviderService not found");
+      throw new AwsWrapperError(Messages.get("HostListProviderService.notFound"));
     }
     return await this.staleDnsHelper.getVerifiedConnection(hostInfo.host, isInitialConnection, this.hostListProviderService, properties, connectFunc);
   }
@@ -58,7 +59,7 @@ export class StaleDnsPlugin extends AbstractConnectionPlugin {
     connectFunc: () => Promise<ClientWrapper>
   ): Promise<ClientWrapper> {
     if (!this.hostListProviderService) {
-      throw new AwsWrapperError("HostListProviderService not found");
+      throw new AwsWrapperError(Messages.get("HostListProviderService.notFound"));
     }
     return await this.staleDnsHelper.getVerifiedConnection(hostInfo.host, isInitialConnection, this.hostListProviderService, properties, connectFunc);
   }

--- a/common/lib/utils/connection_url_parser.ts
+++ b/common/lib/utils/connection_url_parser.ts
@@ -19,6 +19,8 @@ import { HostRole } from "../host_role";
 import { HostInfoBuilder } from "../host_info_builder";
 import { RdsUrlType } from "./rds_url_type";
 import { HostInfo } from "../host_info";
+import { AwsWrapperError } from "../utils/errors";
+import { Messages } from "./messages";
 
 export abstract class ConnectionUrlParser {
   protected static readonly HOST_SEPARATOR = ",";
@@ -70,6 +72,9 @@ export abstract class ConnectionUrlParser {
     fallbackPort: number,
     builderFunc: () => HostInfoBuilder
   ): HostInfo[] {
+    if (!initialConnection) {
+      throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter"));
+    }
     const hostsList: HostInfo[] = [];
     const hosts: string[] = this.getHostPortPairsFromUrl(initialConnection);
     hosts.forEach((pair, i) => {

--- a/common/lib/utils/locales/en.json
+++ b/common/lib/utils/locales/en.json
@@ -1,6 +1,6 @@
 {
   "PluginManager.unknownPluginCode": "Unknown plugin code: '%s'",
-  "PluginManager.PipelineNone": "A pipeline was requested but the created pipeline evaluated to None.",
+  "PluginManager.pipelineNone": "A pipeline was requested but the created pipeline evaluated to undefined.",
   "PluginManager.unableToRetrievePlugin": "Unable to retrieve plugin instance.",
   "ConnectionProvider.unsupportedHostSelectorStrategy": "Unsupported host selection strategy '%s' specified for this connection provider '%s'. Please visit the documentation for all supported strategies.",
   "ConnectionProvider.unsupportedHostInfoSelectorStrategy": "Unsupported host selection strategy '%s' specified for this connection provider '%s'. Please visit the documentation for all supported strategies.",
@@ -12,6 +12,8 @@
   "DefaultConnectionPlugin.unknownRoleRequested": "A HostInfo with a role of HostRole.UNKNOWN was requested via getHostInfoByStrategy. The requested role must be either HostRole.WRITER or HostRole.READER",
   "DefaultConnectionPlugin.noHostsAvailable": "The default connection plugin received an empty host list from the plugin service.",
   "HostSelector.noHostsMatchingRole": "No hosts were found matching the requested '%s' role.",
+  "HostListProviderService.notFound": "HostListProviderService not found.",
+  "HostInfo.noHostParameter": "Host parameter must be set, HostInfo not found or not provided.",
   "HostInfo.weightLessThanZero": "A HostInfo object was created with a weight value less than 0.",
   "AwsSecretsManagerConnectionPlugin.failedToFetchDbCredentials": "Was not able to either fetch or read the database credentials from AWS Secrets Manager. Ensure the correct secretId and region properties have been provided.",
   "AwsSecretsManagerConnectionPlugin.missingRequiredConfigParameter": "Configuration parameter 'secretId' is required.",

--- a/mysql/lib/client.ts
+++ b/mysql/lib/client.ts
@@ -57,7 +57,7 @@ export class AwsMySQLClient extends AwsClient {
     return await context.start(async () => {
       const hostInfo = this.pluginService.getCurrentHostInfo();
       if (hostInfo == null) {
-        throw new AwsWrapperError("HostInfo was not provided.");
+        throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter"));
       }
       const result: ClientWrapper = await this.pluginManager.connect(hostInfo, this.properties, true);
       await this.pluginService.setCurrentClient(result, result.hostInfo);

--- a/pg/lib/client.ts
+++ b/pg/lib/client.ts
@@ -59,7 +59,7 @@ export class AwsPGClient extends AwsClient {
       const hostInfo = this.pluginService.getCurrentHostInfo();
 
       if (hostInfo == null) {
-        throw new AwsWrapperError("HostInfo was not provided.");
+        throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter"));
       }
       const result: ClientWrapper = await this.pluginManager.connect(hostInfo, this.properties, true);
       await this.pluginService.setCurrentClient(result, result.hostInfo);


### PR DESCRIPTION
### Summary

fix: errors thrown in plugin construction may appear as a missing dependency

### Description

Any errors associated with importing and constructing the plugin are swallowed by each plugin's plugin factory which logs the error and then returns `The plugin could not be imported. Please ensure the required dependencies have been installed. Plugin: '<plugin-name>'`

This error was thrown upon attempts to construct the AwsSecretsManagerPlugin without a secretId, even though the error caught correctly identified the issue. The AwsSecretsManagerPlugin is the only plugin currently that has a required property (`secretId`) that is not handled before construction. When any other required property is missing, an error is thrown before reaching the plugin factory. 

Additionally, manipulation of the host property was attempted without first checking if it was provided, this led to confusing error messages. 

Changes: 
- Fix AwsSecretsManagerPluginFactory to return applicable error messaging 
- Correct handling of missing host property 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
