### PR TITLE
chore: separate connection abortion methods

### DIFF
--- a/common/lib/plugin_service.ts
+++ b/common/lib/plugin_service.ts
@@ -389,16 +389,14 @@ export class PluginService implements ErrorHandler, HostListProviderService {
     return await this.getDialect().isClientValid(targetClient);
   }
 
-  async tryClosingTargetClient(): Promise<void>;
-  async tryClosingTargetClient(targetClient: ClientWrapper): Promise<void>;
-  async tryClosingTargetClient(targetClient?: ClientWrapper): Promise<void>;
-  async tryClosingTargetClient(targetClient?: ClientWrapper | undefined): Promise<void> {
-    // Note: This last overload is only required because of the way typescript overloads work https://www.typescriptlang.org/docs/handbook/functions.html#overloads
-    if (targetClient) {
-      await this.getDialect().tryClosingTargetClient(targetClient);
-    } else if (this._currentClient.targetClient) {
+  async abortCurrentClient(): Promise<void> {
+    if (this._currentClient.targetClient) {
       await this.getDialect().tryClosingTargetClient(this._currentClient.targetClient);
     }
+  }
+
+  async tryClosingTargetClient(targetClient: ClientWrapper): Promise<void> {
+    await this.getDialect().tryClosingTargetClient(targetClient);
   }
 
   getSessionStateService() {

--- a/common/lib/plugins/failover/failover_plugin.ts
+++ b/common/lib/plugins/failover/failover_plugin.ts
@@ -352,7 +352,7 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
     }
 
     this.pluginService.getCurrentHostInfo()?.removeAlias(Array.from(oldAliases));
-    await this.pluginService.tryClosingTargetClient();
+    await this.pluginService.abortCurrentClient();
     await this.pluginService.setCurrentClient(result.client, result.newHost);
     await this.updateTopology(true);
   }
@@ -379,7 +379,7 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
       throw new AwsWrapperError();
     }
 
-    await this.pluginService.tryClosingTargetClient();
+    await this.pluginService.abortCurrentClient();
     await this.pluginService.setCurrentClient(result.client, writerHostInfo);
     logger.debug(Messages.get("Failover.establishedConnection", this.pluginService.getCurrentHostInfo()?.host ?? ""));
     await this.pluginService.refreshHostList();
@@ -403,7 +403,7 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
     try {
       const isValid = await client.isValid();
       if (!isValid) {
-        await this.pluginService.tryClosingTargetClient();
+        await this.pluginService.abortCurrentClient();
       }
     } catch (error) {
       // swallow this error, current target client should be useless anyway.

--- a/tests/unit/failover_plugin.test.ts
+++ b/tests/unit/failover_plugin.test.ts
@@ -84,7 +84,7 @@ describe("reader failover handler", () => {
     when(mockRdsHostListProvider.getRdsUrlType()).thenReturn(RdsUrlType.RDS_WRITER_CLUSTER);
     when(mockPluginService.getHostListProvider()).thenReturn(instance(mockRdsHostListProvider));
     when(mockPluginService.getCurrentClient()).thenReturn(instance(mockAwsClient));
-    when(mockPluginService.tryClosingTargetClient()).thenResolve();
+    when(mockPluginService.abortCurrentClient()).thenResolve();
     properties.clear();
   });
 
@@ -399,11 +399,11 @@ describe("reader failover handler", () => {
 
     await plugin.invalidateCurrentClient();
 
-    when(mockPluginService.tryClosingTargetClient()).thenThrow(new Error("test"));
+    when(mockPluginService.abortCurrentClient()).thenThrow(new Error("test"));
 
     await plugin.invalidateCurrentClient();
 
-    verify(mockPluginService.tryClosingTargetClient()).twice();
+    verify(mockPluginService.abortCurrentClient()).twice();
   });
 
   it("test execute", async () => {


### PR DESCRIPTION
### Summary

Separate `tryClosingTargetConn` into two methods, where the other method closes the current client.

### Description

This fixes a bug in the reader failover process.
During the reader failover process, the wrapper spins up two connection attempt tasks using promises. In Node promises cannot be cancelled, so if one connection attempt task succeeded and has already returned a result, the other task will continue to run regardless.
To ensure that whatever resources created by the second connection attempt task gets properly cleaned up the wrapper calls `performFinalCleanUp`:
```ts
  async performFinalCleanup() {
    if (this.taskHandler.getSelectedConnectionAttemptTask(this.failoverTaskId) !== this.taskId) {
      await this.pluginService.tryClosingTargetClient(this.targetClient);
    }
  }
```

If the connection attempt has failed, `this.targetClient` will not have been set and thus will be undefined.
In `tryClosingTargetClient`, if `targetClient` is undefined, it closes the current client instead. In this case, the current client would have been the connection returned by task 1. So this effectively closes the current active connection, and any subsequent queries by the user will fail.
```ts
  async tryClosingTargetClient(targetClient?: ClientWrapper | undefined): Promise<void> {
    if (targetClient) {
      await this.getDialect().tryClosingTargetClient(targetClient);
    } else if (this._currentClient.targetClient) {
      await this.getDialect().tryClosingTargetClient(this._currentClient.targetClient);
    }
  }
```

Alternatively, we could've just added a check in `performFinalCleanup` and skip the `tryClosingTargetClient` call if `this.targetClient`  is undefined. Personally, I think separating the implementation into two separate functions make the intent of each function more clear.

Integration test run: https://github.com/aws/aws-advanced-nodejs-wrapper/actions/runs/11413612799

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
