### PR TITLE
chore: change tough default import to named import

### DIFF
--- a/common/lib/plugins/federated_auth/adfs_credentials_provider_factory.ts
+++ b/common/lib/plugins/federated_auth/adfs_credentials_provider_factory.ts
@@ -21,7 +21,7 @@ import { WrapperProperties } from "../../wrapper_property";
 import { SamlCredentialsProviderFactory } from "./saml_credentials_provider_factory";
 import axios from "axios";
 import { stringify } from "querystring";
-import tough from "tough-cookie";
+import { CookieJar } from "tough-cookie";
 import { wrapper } from "axios-cookiejar-support";
 import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { SamlUtils } from "../../utils/saml_utils";
@@ -109,7 +109,7 @@ export class AdfsCredentialsProviderFactory extends SamlCredentialsProviderFacto
     logger.debug(Messages.get("AdfsCredentialsProviderFactory.signOnPagePostActionUrl", uri));
     SamlUtils.validateUrl(uri);
     wrapper(axios);
-    const jar = new tough.CookieJar();
+    const jar = new CookieJar();
     const httpsAgentOptions = { ...WrapperProperties.HTTPS_AGENT_OPTIONS.get(props), ...{ cookies: { jar } } };
     const httpsAgent = new HttpsCookieAgent(httpsAgentOptions);
 

--- a/mysql/lib/client.ts
+++ b/mysql/lib/client.ts
@@ -212,7 +212,7 @@ export class AwsMySQLClient extends AwsClient {
 
   async end() {
     if (!this.isConnected || !this.targetClient?.client) {
-      // No connections has been initialized.
+      // No connections have been initialized.
       // This might happen if end is called in a finally block when an error occurred while initializing the first connection.
       return;
     }

--- a/pg/lib/client.ts
+++ b/pg/lib/client.ts
@@ -193,7 +193,7 @@ export class AwsPGClient extends AwsClient {
 
   async end() {
     if (!this.isConnected || !this.targetClient?.client) {
-      // No connections has been initialized.
+      // No connections have been initialized.
       // This might happen if end is called in a finally block when an error occurred while initializing the first connection.
       return;
     }

--- a/pg/lib/dialect/pg_database_dialect.ts
+++ b/pg/lib/dialect/pg_database_dialect.ts
@@ -24,10 +24,9 @@ import { TransactionIsolationLevel } from "../../../common/lib/utils/transaction
 import { ClientWrapper } from "../../../common/lib/client_wrapper";
 import { FailoverRestriction } from "../../../common/lib/plugins/failover/failover_restriction";
 import { AwsPoolClient } from "../../../common/lib/aws_pool_client";
-import { AwsMysqlPoolClient } from "../../../mysql/lib/mysql_pool_client";
 import { AwsPgPoolClient } from "../pg_pool_client";
 import { AwsPoolConfig } from "../../../common/lib/aws_pool_config";
-import { PoolClient, PoolConfig } from "pg";
+import { PoolConfig } from "pg";
 import { WrapperProperties } from "../../../common/lib/wrapper_property";
 
 export class PgDatabaseDialect implements DatabaseDialect {


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

- Changes default "tough" import to named "CookieJar" import to prevent issues with tough being undefined
- Removes unused imports

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
