### PR TITLE
chore: migrate to AWS JS SDK v3

### DIFF
--- a/common/lib/plugins/federated_auth/saml_credentials_provider_factory.ts
+++ b/common/lib/plugins/federated_auth/saml_credentials_provider_factory.ts
@@ -18,11 +18,8 @@ import { CredentialsProviderFactory } from "./credentials_provider_factory";
 import { AssumeRoleWithSAMLCommand, STSClient } from "@aws-sdk/client-sts";
 import { WrapperProperties } from "../../wrapper_property";
 
-import pkgAwsSdk from "aws-sdk";
-const { Credentials } = pkgAwsSdk;
-
 import { AwsWrapperError } from "../../utils/errors";
-import { AwsCredentialIdentityProvider, AwsCredentialIdentity } from "@smithy/types/dist-types/identity/awsCredentialIdentity";
+import { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types/dist-types/identity/awsCredentialIdentity";
 import { decode } from "entities";
 
 export abstract class SamlCredentialsProviderFactory implements CredentialsProviderFactory {
@@ -46,11 +43,7 @@ export abstract class SamlCredentialsProviderFactory implements CredentialsProvi
     const credentials = results["Credentials"];
 
     if (credentials && credentials.AccessKeyId && credentials.SecretAccessKey && credentials.SessionToken) {
-      return new Credentials({
-        accessKeyId: credentials.AccessKeyId,
-        secretAccessKey: credentials.SecretAccessKey,
-        sessionToken: credentials.SessionToken
-      });
+      return new AwsCredentials(credentials.AccessKeyId, credentials.SecretAccessKey, credentials.SessionToken);
     }
     throw new AwsWrapperError("Credentials from SAML request not found");
   }
@@ -63,5 +56,23 @@ export abstract class SamlCredentialsProviderFactory implements CredentialsProvi
       return `https://${idpEndpoint}`;
     }
     return idpEndpoint;
+  }
+}
+
+export class AwsCredentials implements AwsCredentialIdentity {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  credentialScope?: string;
+  accountId?: string;
+  expiration?: Date;
+  AccessKeyId: string;
+  SecretAccessKey: string;
+  SessionToken: string;
+
+  constructor(accessKeyId: string, secretAccessKey: string, sessionToken?: string) {
+    this.accessKeyId = accessKeyId;
+    this.secretAccessKey = secretAccessKey;
+    this.sessionToken = sessionToken;
   }
 }

--- a/common/lib/plugins/federated_auth/saml_credentials_provider_factory.ts
+++ b/common/lib/plugins/federated_auth/saml_credentials_provider_factory.ts
@@ -43,7 +43,11 @@ export abstract class SamlCredentialsProviderFactory implements CredentialsProvi
     const credentials = results["Credentials"];
 
     if (credentials && credentials.AccessKeyId && credentials.SecretAccessKey && credentials.SessionToken) {
-      return new AwsCredentials(credentials.AccessKeyId, credentials.SecretAccessKey, credentials.SessionToken);
+      return {
+        accessKeyId: credentials.AccessKeyId,
+        secretAccessKey: credentials.SecretAccessKey,
+        sessionToken: credentials.SessionToken
+      };
     }
     throw new AwsWrapperError("Credentials from SAML request not found");
   }
@@ -56,23 +60,5 @@ export abstract class SamlCredentialsProviderFactory implements CredentialsProvi
       return `https://${idpEndpoint}`;
     }
     return idpEndpoint;
-  }
-}
-
-export class AwsCredentials implements AwsCredentialIdentity {
-  accessKeyId: string;
-  secretAccessKey: string;
-  sessionToken?: string;
-  credentialScope?: string;
-  accountId?: string;
-  expiration?: Date;
-  AccessKeyId: string;
-  SecretAccessKey: string;
-  SessionToken: string;
-
-  constructor(accessKeyId: string, secretAccessKey: string, sessionToken?: string) {
-    this.accessKeyId = accessKeyId;
-    this.secretAccessKey = secretAccessKey;
-    this.sessionToken = sessionToken;
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@types/pg": "^8.11.10",
     "@types/tough-cookie": "^4.0.5",
     "@typescript-eslint/eslint-plugin": "^7.15.0",
-    "aws-sdk": "^2.1691.0",
     "aws-xray-sdk": "^3.10.1",
     "axios": "^1.7.7",
     "axios-cookiejar-support": "^5.0.3",

--- a/tests/unit/federated_auth_plugin.test.ts
+++ b/tests/unit/federated_auth_plugin.test.ts
@@ -22,7 +22,6 @@ import { WrapperProperties } from "../../common/lib/wrapper_property";
 import { anything, instance, mock, spy, verify, when } from "ts-mockito";
 import { CredentialsProviderFactory } from "../../common/lib/plugins/federated_auth/credentials_provider_factory";
 import { DatabaseDialect } from "../../common/lib/database_dialect/database_dialect";
-import { AwsCredentials } from "../../common/lib/plugins/federated_auth/saml_credentials_provider_factory";
 
 import { HostRole } from "../../common/lib/host_role";
 import { NullTelemetryFactory } from "../../common/lib/utils/telemetry/null_telemetry_factory";
@@ -46,7 +45,11 @@ const mockDialectInstance = instance(mockDialect);
 const mockPluginService = mock(PluginService);
 const mockCredentialsProviderFactory = mock<CredentialsProviderFactory>();
 const spyIamUtils = spy(IamAuthUtils);
-const mockCredentials = mock(AwsCredentials);
+const testCredentials = {
+  accessKeyId: "foo",
+  secretAccessKey: "bar",
+  sessionToken: "baz"
+};
 const mockConnectFunc = jest.fn(() => {
   return Promise.resolve(mock(PgClientWrapper));
 });
@@ -59,7 +62,7 @@ describe("federatedAuthTest", () => {
     when(mockPluginService.getDialect()).thenReturn(mockDialectInstance);
     when(mockPluginService.getTelemetryFactory()).thenReturn(new NullTelemetryFactory());
     when(mockDialect.getDefaultPort()).thenReturn(defaultPort);
-    when(mockCredentialsProviderFactory.getAwsCredentialsProvider(anything(), anything(), anything())).thenResolve(instance(mockCredentials));
+    when(mockCredentialsProviderFactory.getAwsCredentialsProvider(anything(), anything(), anything())).thenResolve(instance(testCredentials));
     props = new Map<string, any>();
     WrapperProperties.PLUGINS.set(props, "federatedAuth");
     WrapperProperties.DB_USER.set(props, dbUser);

--- a/tests/unit/federated_auth_plugin.test.ts
+++ b/tests/unit/federated_auth_plugin.test.ts
@@ -22,9 +22,7 @@ import { WrapperProperties } from "../../common/lib/wrapper_property";
 import { anything, instance, mock, spy, verify, when } from "ts-mockito";
 import { CredentialsProviderFactory } from "../../common/lib/plugins/federated_auth/credentials_provider_factory";
 import { DatabaseDialect } from "../../common/lib/database_dialect/database_dialect";
-
-import pkgAwsSdk from "aws-sdk";
-const { Credentials } = pkgAwsSdk;
+import { AwsCredentials } from "../../common/lib/plugins/federated_auth/saml_credentials_provider_factory";
 
 import { HostRole } from "../../common/lib/host_role";
 import { NullTelemetryFactory } from "../../common/lib/utils/telemetry/null_telemetry_factory";
@@ -48,7 +46,7 @@ const mockDialectInstance = instance(mockDialect);
 const mockPluginService = mock(PluginService);
 const mockCredentialsProviderFactory = mock<CredentialsProviderFactory>();
 const spyIamUtils = spy(IamAuthUtils);
-const mockCredentials = mock(Credentials);
+const mockCredentials = mock(AwsCredentials);
 const mockConnectFunc = jest.fn(() => {
   return Promise.resolve(mock(PgClientWrapper));
 });

--- a/tests/unit/okta_auth_plugin.test.ts
+++ b/tests/unit/okta_auth_plugin.test.ts
@@ -22,8 +22,7 @@ import { HostInfo } from "../../common/lib/host_info";
 import { WrapperProperties } from "../../common/lib/wrapper_property";
 import { DatabaseDialect } from "../../common/lib/database_dialect/database_dialect";
 
-import pkgAwsSdk from "aws-sdk";
-const { Credentials } = pkgAwsSdk;
+import { AwsCredentials } from "../../common/lib/plugins/federated_auth/saml_credentials_provider_factory";
 
 import { OktaAuthPlugin } from "../../common/lib/plugins/federated_auth/okta_auth_plugin";
 import { NullTelemetryFactory } from "../../common/lib/utils/telemetry/null_telemetry_factory";
@@ -42,7 +41,7 @@ const testTokenInfo = new TokenInfo(testToken, Date.now() + 300000);
 const mockPluginService = mock(PluginService);
 const mockDialect = mock<DatabaseDialect>();
 const mockDialectInstance = instance(mockDialect);
-const mockCredentials = mock(Credentials);
+const mockCredentials = mock(AwsCredentials);
 const spyIamUtils = spy(IamAuthUtils);
 const mockCredentialsProviderFactory = mock<CredentialsProviderFactory>();
 const mockConnectFunc = jest.fn(() => {


### PR DESCRIPTION
### Summary

Updates wrapper to only use AWS JS SDK v3, as the AWS SDK for JavaScript (v2) is in maintenance mode. 

### Description

Removes the usage of the aws-sdk v2. Additionally, the migration script was run and a manual check for other changes completed. 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
