### PR TITLE
chore: make AwsClient#releaseResouces static

### DIFF
--- a/common/lib/aws_client.ts
+++ b/common/lib/aws_client.ts
@@ -142,10 +142,6 @@ export abstract class AwsClient extends EventEmitter {
     return await this.pluginService.isClientValid(this.targetClient);
   }
 
-  async releaseResources(): Promise<any> {
-    await this.pluginManager.releaseResources();
-  }
-
   getPluginInstance<T>(iface: any): T {
     return this.pluginManager.getPluginInstance(iface);
   }

--- a/mysql/lib/client.ts
+++ b/mysql/lib/client.ts
@@ -31,6 +31,7 @@ import { ClientUtils } from "../../common/lib/utils/client_utils";
 import { RdsMultiAZMySQLDatabaseDialect } from "./dialect/rds_multi_az_mysql_database_dialect";
 import { TelemetryTraceLevel } from "../../common/lib/utils/telemetry/telemetry_trace_level";
 import { MySQL2DriverDialect } from "./dialect/mysql2_driver_dialect";
+import { PluginManager } from "../../common/lib";
 
 export class AwsMySQLClient extends AwsClient {
   private static readonly knownDialectsByCode: Map<string, DatabaseDialect> = new Map([
@@ -212,7 +213,7 @@ export class AwsMySQLClient extends AwsClient {
       },
       null
     );
-    await this.releaseResources();
+    await PluginManager.releaseResources();
     return result;
   }
 

--- a/mysql/lib/client.ts
+++ b/mysql/lib/client.ts
@@ -213,7 +213,6 @@ export class AwsMySQLClient extends AwsClient {
       },
       null
     );
-    await PluginManager.releaseResources();
     return result;
   }
 

--- a/pg/lib/client.ts
+++ b/pg/lib/client.ts
@@ -30,7 +30,6 @@ import { RdsMultiAZPgDatabaseDialect } from "./dialect/rds_multi_az_pg_database_
 import { HostInfo } from "../../common/lib/host_info";
 import { TelemetryTraceLevel } from "../../common/lib/utils/telemetry/telemetry_trace_level";
 import { NodePostgresDriverDialect } from "./dialect/node_postgres_driver_dialect";
-import { PluginManager } from "../../common/lib";
 
 export class AwsPGClient extends AwsClient {
   private static readonly knownDialectsByCode: Map<string, DatabaseDialect> = new Map([
@@ -190,7 +189,6 @@ export class AwsPGClient extends AwsClient {
       },
       null
     );
-    await PluginManager.releaseResources();
     return result;
   }
 

--- a/pg/lib/client.ts
+++ b/pg/lib/client.ts
@@ -30,6 +30,7 @@ import { RdsMultiAZPgDatabaseDialect } from "./dialect/rds_multi_az_pg_database_
 import { HostInfo } from "../../common/lib/host_info";
 import { TelemetryTraceLevel } from "../../common/lib/utils/telemetry/telemetry_trace_level";
 import { NodePostgresDriverDialect } from "./dialect/node_postgres_driver_dialect";
+import { PluginManager } from "../../common/lib";
 
 export class AwsPGClient extends AwsClient {
   private static readonly knownDialectsByCode: Map<string, DatabaseDialect> = new Map([
@@ -189,7 +190,7 @@ export class AwsPGClient extends AwsClient {
       },
       null
     );
-    await this.releaseResources();
+    await PluginManager.releaseResources();
     return result;
   }
 

--- a/tests/integration/container/tests/aurora_failover.test.ts
+++ b/tests/integration/container/tests/aurora_failover.test.ts
@@ -25,6 +25,7 @@ import { RdsUtils } from "../../../../common/lib/utils/rds_utils";
 import { logger } from "../../../../common/logutils";
 import { features, instanceCount } from "./config";
 import { TestEnvironmentFeatures } from "./utils/test_environment_features";
+import { PluginManager } from "../../../../common/lib";
 
 const itIf =
   features.includes(TestEnvironmentFeatures.FAILOVER_SUPPORTED) &&
@@ -94,6 +95,7 @@ describe("aurora failover", () => {
         // pass
       }
     }
+    await PluginManager.releaseResources();
     logger.info(`Test finished: ${expect.getState().currentTestName}`);
   }, 1320000);
 

--- a/tests/integration/container/tests/autoscaling.test.ts
+++ b/tests/integration/container/tests/autoscaling.test.ts
@@ -26,6 +26,7 @@ import { ConnectionProviderManager } from "../../../../common/lib/connection_pro
 import { TestInstanceInfo } from "./utils/test_instance_info";
 import { sleep } from "../../../../common/lib/utils/utils";
 import { FailoverSuccessError } from "../../../../common/lib/utils/errors";
+import { PluginManager } from "../../../../common/lib";
 
 const itIf =
   !features.includes(TestEnvironmentFeatures.PERFORMANCE) &&
@@ -109,6 +110,7 @@ describe("pooled connection autoscaling", () => {
         // pass
       }
     }
+    await PluginManager.releaseResources();
     logger.info(`Test finished: ${expect.getState().currentTestName}`);
   }, 1320000);
 

--- a/tests/integration/container/tests/basic_connectivity.test.ts
+++ b/tests/integration/container/tests/basic_connectivity.test.ts
@@ -23,6 +23,7 @@ import { DatabaseEngine } from "./utils/database_engine";
 import { TestEnvironmentFeatures } from "./utils/test_environment_features";
 import { features } from "./config";
 import { DatabaseEngineDeployment } from "./utils/database_engine_deployment";
+import { PluginManager } from "../../../../common/lib";
 
 const itIf =
   !features.includes(TestEnvironmentFeatures.PERFORMANCE) && !features.includes(TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY) ? it : it.skip;
@@ -54,6 +55,7 @@ afterEach(async () => {
       // pass
     }
   }
+  await PluginManager.releaseResources();
   logger.info(`Test finished: ${expect.getState().currentTestName}`);
 }, 1320000);
 

--- a/tests/integration/container/tests/iam_authentication.test.ts
+++ b/tests/integration/container/tests/iam_authentication.test.ts
@@ -26,6 +26,7 @@ import { IamAuthenticationPlugin } from "../../../../common/lib/authentication/i
 import { logger } from "../../../../common/logutils";
 import { TestEnvironmentFeatures } from "./utils/test_environment_features";
 import { features } from "./config";
+import { PluginManager } from "../../../../common/lib";
 
 const itIf =
   !features.includes(TestEnvironmentFeatures.PERFORMANCE) &&
@@ -89,6 +90,7 @@ describe("iam authentication", () => {
   });
 
   afterEach(async () => {
+    await PluginManager.releaseResources();
     await TestEnvironment.verifyClusterStatus();
     logger.info(`Test finished: ${expect.getState().currentTestName}`);
   }, 1320000);

--- a/tests/integration/container/tests/performance.test.ts
+++ b/tests/integration/container/tests/performance.test.ts
@@ -26,6 +26,7 @@ import { features } from "./config";
 import { MonitorServiceImpl } from "../../../../common/lib/plugins/efm/monitor_service";
 import { PerfStat } from "./utils/perf_stat";
 import { PerfTestUtility } from "./utils/perf_util";
+import { PluginManager } from "../../../../common/lib";
 
 const itIf =
   features.includes(TestEnvironmentFeatures.FAILOVER_SUPPORTED) &&
@@ -253,6 +254,7 @@ describe("performance", () => {
   });
 
   afterEach(async () => {
+    await PluginManager.releaseResources();
     await TestEnvironment.verifyClusterStatus();
     logger.info(`Test finished: ${expect.getState().currentTestName}`);
   }, 1320000);

--- a/tests/integration/container/tests/read_write_splitting.test.ts
+++ b/tests/integration/container/tests/read_write_splitting.test.ts
@@ -29,6 +29,7 @@ import { AwsPoolConfig } from "../../../../common/lib/aws_pool_config";
 import { ConnectionProviderManager } from "../../../../common/lib/connection_provider_manager";
 import { InternalPoolMapping } from "../../../../common/lib/utils/internal_pool_mapping";
 import { HostInfo } from "../../../../common/lib/host_info";
+import { PluginManager } from "../../../../common/lib";
 
 const itIf =
   !features.includes(TestEnvironmentFeatures.PERFORMANCE) &&
@@ -121,6 +122,7 @@ describe("aurora read write splitting", () => {
         // pass
       }
     }
+    await PluginManager.releaseResources();
     logger.info(`Test finished: ${expect.getState().currentTestName}`);
   }, 1320000);
 

--- a/tests/integration/container/tests/read_write_splitting_performance.test.ts
+++ b/tests/integration/container/tests/read_write_splitting_performance.test.ts
@@ -26,6 +26,7 @@ import { ExecuteTimePlugin } from "../../../../common/lib/plugins/execute_time_p
 import { TestDriver } from "./utils/test_driver";
 import { ConnectionProviderManager } from "../../../../common/lib/connection_provider_manager";
 import { InternalPooledConnectionProvider } from "../../../../common/lib/internal_pooled_connection_provider";
+import { PluginManager } from "../../../../common/lib";
 
 const itIf =
   features.includes(TestEnvironmentFeatures.FAILOVER_SUPPORTED) &&
@@ -52,6 +53,7 @@ describe("rwperformance", () => {
   });
 
   afterEach(async () => {
+    await PluginManager.releaseResources();
     logger.info(`Test finished: ${expect.getState().currentTestName}`);
   }, 1320000);
 

--- a/tests/plugin_benchmarks.ts
+++ b/tests/plugin_benchmarks.ts
@@ -78,7 +78,7 @@ suite(
     const pluginManager = getPluginManager(props);
     const wrapper = new TestConnectionWrapper(props, pluginManager, instance(mockPluginService));
     await pluginManager.init();
-    await wrapper.releaseResources();
+    await PluginManager.releaseResources();
   }),
 
   add("initAndReleaseWithExecuteTimePlugin", async () => {
@@ -86,7 +86,7 @@ suite(
     const pluginManager = getPluginManager(props);
     const wrapper = new TestConnectionWrapper(props, pluginManager, instance(mockPluginService));
     await pluginManager.init();
-    await wrapper.releaseResources();
+    await PluginManager.releaseResources();
   }),
 
   add("initAndReleaseWithReadWriteSplittingPlugin", async () => {
@@ -94,7 +94,7 @@ suite(
     const pluginManager = getPluginManager(props);
     const wrapper = new TestConnectionWrapper(props, pluginManager, instance(mockPluginService));
     await pluginManager.init();
-    await wrapper.releaseResources();
+    await PluginManager.releaseResources();
   }),
 
   add("executeStatementBaseline", async () => {

--- a/tests/plugin_manager_benchmarks.ts
+++ b/tests/plugin_manager_benchmarks.ts
@@ -350,37 +350,37 @@ suite(
   add("releaseResourcesWithNoPlugins", async () => {
     const pluginManagerWithNoPlugins = getPluginManagerWithNoPlugins();
     await pluginManagerWithNoPlugins.init();
-    return async () => await pluginManagerWithNoPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add("releaseResourcesWith1Plugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init(await createPlugins(1, instance(mockPluginService), instance(mockConnectionProvider), propsWithPlugins));
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add("releaseResourcesWith2Plugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init(await createPlugins(2, instance(mockPluginService), instance(mockConnectionProvider), propsWithPlugins));
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add("releaseResourcesWith5Plugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init(await createPlugins(5, instance(mockPluginService), instance(mockConnectionProvider), propsWithPlugins));
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add("releaseResourcesWith10Plugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init(await createPlugins(10, instance(mockPluginService), instance(mockConnectionProvider), propsWithPlugins));
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add.only("releaseResourcesWithDefaultPlugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init();
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   cycle(),

--- a/tests/plugin_manager_telemetry_benchmarks.ts
+++ b/tests/plugin_manager_telemetry_benchmarks.ts
@@ -410,37 +410,37 @@ suite(
   add("releaseResourcesWithNoPlugins", async () => {
     const pluginManagerWithNoPlugins = getPluginManagerWithNoPlugins();
     await pluginManagerWithNoPlugins.init();
-    return async () => await pluginManagerWithNoPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add("releaseResourcesWith1Plugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init(await createPlugins(1, instance(mockPluginService), instance(mockConnectionProvider), propsWithPlugins));
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add("releaseResourcesWith2Plugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init(await createPlugins(2, instance(mockPluginService), instance(mockConnectionProvider), propsWithPlugins));
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add("releaseResourcesWith5Plugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init(await createPlugins(5, instance(mockPluginService), instance(mockConnectionProvider), propsWithPlugins));
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add("releaseResourcesWith10Plugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init(await createPlugins(10, instance(mockPluginService), instance(mockConnectionProvider), propsWithPlugins));
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   add.only("releaseResourcesWithDefaultPlugins", async () => {
     const pluginManagerWithPlugins = getPluginManagerWithPlugins();
     await pluginManagerWithPlugins.init();
-    return async () => await pluginManagerWithPlugins.releaseResources();
+    return async () => await PluginManager.releaseResources();
   }),
 
   cycle(),

--- a/tests/plugin_telemetry_benchmarks.ts
+++ b/tests/plugin_telemetry_benchmarks.ts
@@ -154,21 +154,21 @@ suite(
   add("initAndReleaseBaseline", async () => {
     const wrapper = new TestConnectionWrapper(props, pluginManager, instance(mockPluginService));
     await pluginManager.init();
-    await wrapper.releaseResources();
+    await PluginManager.releaseResources();
     await wrapper.end();
   }),
 
   add("initAndReleaseWithExecuteTimePlugin", async () => {
     const wrapper = new TestConnectionWrapper(propsExecute, pluginManagerExecute, instance(mockPluginService));
     await pluginManagerExecute.init();
-    await wrapper.releaseResources();
+    await PluginManager.releaseResources();
     await wrapper.end();
   }),
 
   add("initAndReleaseWithReadWriteSplittingPlugin", async () => {
     const wrapper = new TestConnectionWrapper(propsReadWrite, pluginManagerReadWrite, instance(mockPluginService));
     await pluginManagerReadWrite.init();
-    await wrapper.releaseResources();
+    await PluginManager.releaseResources();
     await wrapper.end();
   }),
 


### PR DESCRIPTION
### Summary

Update releaseResources to be a static method. 

### Description

Introduced a static set to track all the plugins in PluginManager that releases all resources when Client.end is called. 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
