### PR TITLE
bug: session state logs

### DIFF
--- a/common/lib/session_state.ts
+++ b/common/lib/session_state.ts
@@ -74,7 +74,7 @@ class SessionStateField<Type> {
   }
 
   toString() {
-    return `${this.pristineValue ? this.pristineValue : "(blank)"} => ${this.value ? this.value : "(blank)"}`;
+    return `${this.pristineValue ?? "(blank)"} => ${this.value ?? "(blank)"}`;
   }
 }
 


### PR DESCRIPTION
### Summary

Update session state logging to display false values as false instead of as (blank). 

### Description

Previously, upon calling Client.setReadOnly(false) the session state would display as: 
```
Current session state:
    autoCommit: (blank) => (blank)
    
    readOnly: (blank) => (blank)
    
    catalog: (blank) => (blank)
    
    schema: (blank) => (blank)
    
    transactionIsolation: (blank) => (blank)
```

With this change it correctly displays as: 
```
Current session state:
    autoCommit: (blank) => (blank)
    
    readOnly: false => false
    
    catalog: (blank) => (blank)
    
    schema: (blank) => (blank)
    
    transactionIsolation: (blank) => (blank)
```

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
