### PR TITLE
fix: integration tests with connectionProvider

### DIFF
--- a/common/lib/connection_provider_manager.ts
+++ b/common/lib/connection_provider_manager.ts
@@ -60,4 +60,8 @@ export class ConnectionProviderManager {
 
     return host;
   }
+
+  getDefaultConnectionProvider(): ConnectionProvider {
+    return this.defaultProvider;
+  }
 }

--- a/common/lib/plugins/default_plugin.ts
+++ b/common/lib/plugins/default_plugin.ts
@@ -51,7 +51,7 @@ export class DefaultPlugin extends AbstractConnectionPlugin {
     isInitialConnection: boolean,
     forceConnectFunc: () => Promise<ClientWrapper>
   ): Promise<ClientWrapper> {
-    return await this.connectInternal(hostInfo, props, this.connectionProviderManager.getConnectionProvider(hostInfo, props));
+    return await this.connectInternal(hostInfo, props, this.connectionProviderManager.getDefaultConnectionProvider());
   }
 
   override initHostProvider(

--- a/common/lib/utils/utils.ts
+++ b/common/lib/utils/utils.ts
@@ -57,6 +57,8 @@ export function maskProperties(props: Map<string, any>) {
   if (maskedProperties.has(WrapperProperties.PASSWORD.name)) {
     maskedProperties.set(WrapperProperties.PASSWORD.name, "***");
   }
+  // Remove connectionProvider property before displaying. AwsMysqlPoolClient.targetPool throws
+  // "TypeError: Converting circular structure to JSON" when sent to JSON.stringify.
   maskedProperties.delete(WrapperProperties.CONNECTION_PROVIDER.name);
   return maskedProperties;
 }

--- a/common/lib/utils/utils.ts
+++ b/common/lib/utils/utils.ts
@@ -57,6 +57,7 @@ export function maskProperties(props: Map<string, any>) {
   if (maskedProperties.has(WrapperProperties.PASSWORD.name)) {
     maskedProperties.set(WrapperProperties.PASSWORD.name, "***");
   }
+  maskedProperties.delete(WrapperProperties.CONNECTION_PROVIDER.name);
   return maskedProperties;
 }
 

--- a/tests/integration/container/tests/read_write_splitting.test.ts
+++ b/tests/integration/container/tests/read_write_splitting.test.ts
@@ -649,6 +649,7 @@ describe("aurora read write splitting", () => {
         for (let i = 0; i < numOverloadedReaderConnections; i++) {
           const readerConfig = await initDefaultConfig(env.databaseInfo.readerInstanceEndpoint, env.databaseInfo.instanceEndpointPort, false);
           readerConfig["arbitraryProp"] = "value" + i.toString();
+          readerConfig["connectionProvider"] = provider;
           readerConfig["readerHostSelectorStrategy"] = "leastConnections";
           const client = initClientFunc(readerConfig);
           await client.connect();


### PR DESCRIPTION
### Summary

Fixes the failing integration tests as a result of [#330](https://github.com/aws/aws-advanced-nodejs-wrapper/pull/330).

### Description

Correctly assigns connectionProvider. Removes connectionProvider from list of properties sent to JSON.stringify. 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
