### PR TITLE
docs: include PluginManager.releaseResources

### DIFF
--- a/docs/development-guide/PluginManager.md
+++ b/docs/development-guide/PluginManager.md
@@ -9,6 +9,10 @@ The plugin manager has the following main functionalities:
 
 The plugin manager initializes all plugins with codes given to the [`plugins`](../using-the-nodejs-wrapper/UsingTheNodejsWrapper.md#connection-plugin-manager-parameters) connection parameter.
 
+### Clean Up Resources
+
+The Aurora Connection Tracker Plugin, Host Monitoring Connection Plugin, and Read/Write Splitting Plugin can have shared resources. The plugin manager handles cleaning up resources that may be shared between connections at the end of an application through the `releaseResources` method.
+
 ## Initiate Pipelines
 
 <div style="center"><img src="../images/initiate_pipelines.png" alt="diagram for the plugin service design"/></div>

--- a/docs/using-the-nodejs-wrapper/using-plugins/UsingTheAuroraConnectionTrackerPlugin.md
+++ b/docs/using-the-nodejs-wrapper/using-plugins/UsingTheAuroraConnectionTrackerPlugin.md
@@ -16,3 +16,6 @@ When the application tries to continue the workflow with the idle connection tha
 
 Since the Aurora Connection Tracker Plugin keeps track of all the open connections, the plugin can close all impacted connections after failover.
 When the application tries to use the outdated idle connection, the application will get an error such as `Can't add new command when connection is in closed state` instead.
+
+> [!WARNING]
+> Connections with the Aurora Connection Tracker Plugin may have cached resources used throughout multiple connections. To clean up any resources used by the plugins at the end of the application call `await PluginManager.releaseResources()`.

--- a/docs/using-the-nodejs-wrapper/using-plugins/UsingTheHostMonitoringPlugin.md
+++ b/docs/using-the-nodejs-wrapper/using-plugins/UsingTheHostMonitoringPlugin.md
@@ -83,3 +83,6 @@ await client.connect();
 > We recommend you either disable the Host Monitoring Connection Plugin or avoid using RDS Proxy endpoints when the Host Monitoring Connection Plugin is active.
 >
 > Although using RDS Proxy endpoints with the AWS Advanced NodeJS Wrapper with Enhanced Failure Monitoring doesn't cause any critical issues, we don't recommend this approach. The main reason is that RDS Proxy transparently re-routes requests to a single database instance. RDS Proxy decides which database instance is used based on many criteria (on a per-request basis). Switching between different instances makes the Host Monitoring Connection Plugin useless in terms of instance health monitoring because the plugin will be unable to identify which instance it's connected to, and which one it's monitoring. This could result in false positive failure detections. At the same time, the plugin will still proactively monitor connectivity to RDS Proxy endpoints and report outages back to a user application if they occur.
+
+> [!WARNING]
+> Connections with the Host Monitoring Connection Plugin may have cached resources used throughout multiple connections. To clean up any resources used by the plugins at the end of the application call `await PluginManager.releaseResources()`.

--- a/docs/using-the-nodejs-wrapper/using-plugins/UsingTheReadWriteSplittingPlugin.md
+++ b/docs/using-the-nodejs-wrapper/using-plugins/UsingTheReadWriteSplittingPlugin.md
@@ -138,3 +138,6 @@ await client.connect();
 const client = new AwsPGClient(params);
 await client.connect();
 ```
+
+> [!WARNING]
+> Connections with the Read/Write Splitting Plugin may have cached resources used throughout multiple connections. To clean up any resources used by the plugins at the end of the application call `await PluginManager.releaseResources()`.

--- a/examples/aws_driver_example/aws_interal_connection_pool_password_warning_postgres_example.ts
+++ b/examples/aws_driver_example/aws_interal_connection_pool_password_warning_postgres_example.ts
@@ -18,6 +18,7 @@ import { ConnectionProviderManager } from "../../common/lib/connection_provider_
 import { InternalPooledConnectionProvider } from "../../common/lib/internal_pooled_connection_provider";
 import { logger } from "../../common/logutils";
 import { AwsPGClient } from "../../pg/lib";
+import { PluginManager } from "../../common/lib";
 
 const postgresHost = "db-identifier.XYZ.us-east-2.rds.amazonaws.com";
 const username = "john_smith";
@@ -91,3 +92,6 @@ try {
 } finally {
   logger.debug("example complete");
 }
+
+// Clean up resources used by the plugins.
+await PluginManager.releaseResources();

--- a/examples/aws_driver_example/aws_internal_connection_pool_password_warning_mysql_example.ts
+++ b/examples/aws_driver_example/aws_internal_connection_pool_password_warning_mysql_example.ts
@@ -18,6 +18,7 @@ import { AwsMySQLClient } from "../../mysql/lib";
 import { ConnectionProviderManager } from "../../common/lib/connection_provider_manager";
 import { InternalPooledConnectionProvider } from "../../common/lib/internal_pooled_connection_provider";
 import { logger } from "../../common/logutils";
+import { PluginManager } from "../../common/lib";
 
 const mysqlHost = "db-identifier.XYZ.us-east-2.rds.amazonaws.com";
 const username = "john_smith";
@@ -91,3 +92,6 @@ try {
 } finally {
   logger.debug("example complete");
 }
+
+// Clean up resources used by the plugins.
+await PluginManager.releaseResources();

--- a/examples/aws_driver_example/aws_internal_connection_pooling_mysql_example.ts
+++ b/examples/aws_driver_example/aws_internal_connection_pooling_mysql_example.ts
@@ -22,6 +22,7 @@ import { WrapperProperties } from "../../common/lib/wrapper_property";
 import { InternalPooledConnectionProvider } from "../../common/lib/internal_pooled_connection_provider";
 import { ConnectionProviderManager } from "../../common/lib/connection_provider_manager";
 import { AwsPoolConfig } from "../../common/lib/aws_pool_config";
+import { PluginManager } from "../../common/lib";
 
 const mysqlHost = "db-identifier.XYZ.us-east-2.rds.amazonaws.com";
 const username = "john_smith";
@@ -137,3 +138,6 @@ async function queryWithFailoverHandling(client: AwsMySQLClient, query: string) 
     }
   }
 }
+
+// Clean up resources used by the plugins.
+await PluginManager.releaseResources();

--- a/examples/aws_driver_example/aws_internal_connection_pooling_postgres_example.ts
+++ b/examples/aws_driver_example/aws_internal_connection_pooling_postgres_example.ts
@@ -22,6 +22,7 @@ import { InternalPoolMapping } from "../../common/lib/utils/internal_pool_mappin
 import { ConnectionProviderManager } from "../../common/lib/connection_provider_manager";
 import { WrapperProperties } from "../../common/lib/wrapper_property";
 import { AwsPoolConfig } from "../../common/lib/aws_pool_config";
+import { PluginManager } from "../../common/lib";
 
 const postgresHost = "db-identifier.XYZ.us-east-2.rds.amazonaws.com";
 const username = "john_smith";
@@ -137,3 +138,6 @@ async function queryWithFailoverHandling(client: AwsPGClient, query: string) {
     }
   }
 }
+
+// Clean up resources used by the plugins.
+await PluginManager.releaseResources();

--- a/examples/aws_driver_example/aws_read_write_splitting_mysql_example.ts
+++ b/examples/aws_driver_example/aws_read_write_splitting_mysql_example.ts
@@ -16,6 +16,7 @@
 
 import { AwsMySQLClient } from "../../mysql/lib";
 import { FailoverFailedError, FailoverSuccessError, TransactionResolutionUnknownError } from "../../common/lib/utils/errors";
+import { PluginManager } from "../../common/lib";
 
 const mysqlHost = "db-identifier.XYZ.us-east-2.rds.amazonaws.com";
 const username = "john_smith";
@@ -105,3 +106,6 @@ async function queryWithFailoverHandling(client: AwsMySQLClient, query: string) 
     }
   }
 }
+
+// Clean up resources used by the plugins.
+await PluginManager.releaseResources();

--- a/examples/aws_driver_example/aws_read_write_splitting_postgresql_example.ts
+++ b/examples/aws_driver_example/aws_read_write_splitting_postgresql_example.ts
@@ -16,6 +16,7 @@
 
 import { AwsPGClient } from "../../pg/lib";
 import { FailoverFailedError, FailoverSuccessError, TransactionResolutionUnknownError } from "../../common/lib/utils/errors";
+import { PluginManager } from "../../common/lib";
 
 const postgresHost = "db-identifier.XYZ.us-east-2.rds.amazonaws.com";
 const username = "john_smith";
@@ -105,3 +106,6 @@ async function queryWithFailoverHandling(client: AwsPGClient, query: string) {
     }
   }
 }
+
+// Clean up resources used by the plugins.
+await PluginManager.releaseResources();


### PR DESCRIPTION
### Summary

Update documentation and example code to release shared resources. 

### Description

chore: make AwsClient#releaseResouces static (https://github.com/aws/aws-advanced-nodejs-wrapper/pull/333) introduced a static method releaseResources to be done at the end of the application. 

- Add warnings to call this method at the end of applications that have shared resources.
- Include a call to this method in examples. 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
