### PR TITLE
fix: incorrect properties passed to pool client

### DIFF
--- a/mysql/lib/dialect/mysql2_driver_dialect.ts
+++ b/mysql/lib/dialect/mysql2_driver_dialect.ts
@@ -48,7 +48,7 @@ export class MySQL2DriverDialect implements DriverDialect {
     const finalPoolConfig: PoolOptions = {};
     const finalClientProps = WrapperProperties.removeWrapperProperties(props);
 
-    Object.assign(finalPoolConfig, finalClientProps);
+    Object.assign(finalPoolConfig, Object.fromEntries(finalClientProps.entries()));
     finalPoolConfig.connectionLimit = poolConfig?.maxConnections;
     finalPoolConfig.idleTimeout = poolConfig?.idleTimeoutMillis;
     finalPoolConfig.maxIdle = poolConfig?.maxIdleConnections;

--- a/pg/lib/dialect/node_postgres_driver_dialect.ts
+++ b/pg/lib/dialect/node_postgres_driver_dialect.ts
@@ -51,7 +51,7 @@ export class NodePostgresDriverDialect implements DriverDialect {
     const finalPoolConfig: pkgPg.PoolConfig = {};
     const finalClientProps = WrapperProperties.removeWrapperProperties(props);
 
-    Object.assign(finalPoolConfig, finalClientProps);
+    Object.assign(finalPoolConfig, Object.fromEntries(finalClientProps.entries()));
     finalPoolConfig.max = poolConfig?.maxConnections;
     finalPoolConfig.idleTimeoutMillis = poolConfig?.idleTimeoutMillis;
     finalPoolConfig.allowExitOnIdle = poolConfig?.allowExitOnIdle;


### PR DESCRIPTION
### Summary

Empty properties passed to pool client because of incorrect conversions

Integration test runs:
- https://github.com/aws/aws-advanced-nodejs-wrapper/actions/runs/12304478123
- https://github.com/aws/aws-advanced-nodejs-wrapper/actions/runs/12304482124

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
