### PR TITLE
test: configure fake timers for iam tests

### DIFF
--- a/common/lib/driver_connection_provider.ts
+++ b/common/lib/driver_connection_provider.ts
@@ -97,7 +97,7 @@ export class DriverConnectionProvider implements ConnectionProvider {
           JSON.stringify(Object.fromEntries(maskProperties(resultProps)))
       );
 
-      resultTargetClient = driverDialect.connect(hostInfo, resultProps);
+      resultTargetClient = await driverDialect.connect(hostInfo, resultProps);
     }
     pluginService.attachErrorListener(resultTargetClient);
     return resultTargetClient;

--- a/common/lib/driver_connection_provider.ts
+++ b/common/lib/driver_connection_provider.ts
@@ -97,7 +97,7 @@ export class DriverConnectionProvider implements ConnectionProvider {
           JSON.stringify(Object.fromEntries(maskProperties(resultProps)))
       );
 
-      resultTargetClient = await driverDialect.connect(hostInfo, resultProps);
+      resultTargetClient = driverDialect.connect(hostInfo, resultProps);
     }
     pluginService.attachErrorListener(resultTargetClient);
     return resultTargetClient;

--- a/docs/using-the-nodejs-wrapper/using-plugins/UsingTheReadWriteSplittingPlugin.md
+++ b/docs/using-the-nodejs-wrapper/using-plugins/UsingTheReadWriteSplittingPlugin.md
@@ -107,7 +107,7 @@ props.set("connectionProvider", provider);
 
 > [!IMPORTANT]
 > To ensure the provider can close the pools, call `await PluginManager.releaseResources()` first.
-> 
+>
 > You must call `await provider.releaseResources()` to close the internal connection pools when you are finished using all connections. Unless `await ConnectionProviderManager.releaseResources()` is called, the wrapper driver will keep the pools open so that they can be shared between connections.
 
 ### Reader Selection

--- a/docs/using-the-nodejs-wrapper/using-plugins/UsingTheReadWriteSplittingPlugin.md
+++ b/docs/using-the-nodejs-wrapper/using-plugins/UsingTheReadWriteSplittingPlugin.md
@@ -103,9 +103,11 @@ props.set("connectionProvider", provider);
 
 4. Continue as normal: create connections and use them as needed.
 
-5. When you are finished using all connections, call `await provider.releaseResources()`.
+5. When you are finished using all connections, call `await PluginManager.releaseResources()`, and then `await provider.releaseResources()`.
 
 > [!IMPORTANT]
+> To ensure the provider can close the pools, call `await PluginManager.releaseResources()` first.
+> 
 > You must call `await provider.releaseResources()` to close the internal connection pools when you are finished using all connections. Unless `await ConnectionProviderManager.releaseResources()` is called, the wrapper driver will keep the pools open so that they can be shared between connections.
 
 ### Reader Selection

--- a/examples/aws_driver_example/aws_interal_connection_pool_password_warning_postgres_example.ts
+++ b/examples/aws_driver_example/aws_interal_connection_pool_password_warning_postgres_example.ts
@@ -72,8 +72,7 @@ try {
 } finally {
   await newClient.end();
 }
-// Clean up resources used by the plugins.
-await PluginManager.releaseResources();
+
 // Closes all pools and removes all cached pool connections.
 await provider.releaseResources();
 
@@ -92,5 +91,8 @@ try {
   await newClient2.connect();
   // Will not reach - exception will be thrown
 } finally {
+  // Clean up resources used by the plugins.
+  await PluginManager.releaseResources();
+
   logger.debug("example complete");
 }

--- a/examples/aws_driver_example/aws_interal_connection_pool_password_warning_postgres_example.ts
+++ b/examples/aws_driver_example/aws_interal_connection_pool_password_warning_postgres_example.ts
@@ -72,6 +72,8 @@ try {
 } finally {
   await newClient.end();
 }
+// Clean up resources used by the plugins.
+await PluginManager.releaseResources();
 // Closes all pools and removes all cached pool connections.
 await provider.releaseResources();
 
@@ -92,6 +94,3 @@ try {
 } finally {
   logger.debug("example complete");
 }
-
-// Clean up resources used by the plugins.
-await PluginManager.releaseResources();

--- a/examples/aws_driver_example/aws_internal_connection_pool_password_warning_mysql_example.ts
+++ b/examples/aws_driver_example/aws_internal_connection_pool_password_warning_mysql_example.ts
@@ -72,6 +72,9 @@ try {
 } finally {
   await newClient.end();
 }
+// Clean up resources used by the plugins.
+await PluginManager.releaseResources();
+
 // Closes all pools and removes all cached pool connections.
 await provider.releaseResources();
 
@@ -92,6 +95,3 @@ try {
 } finally {
   logger.debug("example complete");
 }
-
-// Clean up resources used by the plugins.
-await PluginManager.releaseResources();

--- a/examples/aws_driver_example/aws_internal_connection_pool_password_warning_mysql_example.ts
+++ b/examples/aws_driver_example/aws_internal_connection_pool_password_warning_mysql_example.ts
@@ -72,8 +72,6 @@ try {
 } finally {
   await newClient.end();
 }
-// Clean up resources used by the plugins.
-await PluginManager.releaseResources();
 
 // Closes all pools and removes all cached pool connections.
 await provider.releaseResources();
@@ -93,5 +91,8 @@ try {
   await newClient2.connect();
   // Will not reach - exception will be thrown.
 } finally {
+  // Clean up resources used by the plugins.
+  await PluginManager.releaseResources();
+
   logger.debug("example complete");
 }

--- a/examples/aws_driver_example/aws_internal_connection_pooling_mysql_example.ts
+++ b/examples/aws_driver_example/aws_internal_connection_pooling_mysql_example.ts
@@ -108,6 +108,9 @@ try {
 } finally {
   await client.end();
 
+  // Clean up resources used by the plugins.
+  await PluginManager.releaseResources();
+
   // If configured to use internal connection pools, close them here.
   await provider.releaseResources();
 }
@@ -138,6 +141,3 @@ async function queryWithFailoverHandling(client: AwsMySQLClient, query: string) 
     }
   }
 }
-
-// Clean up resources used by the plugins.
-await PluginManager.releaseResources();

--- a/examples/aws_driver_example/aws_internal_connection_pooling_postgres_example.ts
+++ b/examples/aws_driver_example/aws_internal_connection_pooling_postgres_example.ts
@@ -108,6 +108,9 @@ try {
 } finally {
   await client.end();
 
+  // Clean up resources used by the plugins.
+  await PluginManager.releaseResources();
+
   // If configured to use internal connection pools, close them here.
   await provider.releaseResources();
 }
@@ -138,6 +141,3 @@ async function queryWithFailoverHandling(client: AwsPGClient, query: string) {
     }
   }
 }
-
-// Clean up resources used by the plugins.
-await PluginManager.releaseResources();

--- a/tests/integration/container/tests/iam_authentication.test.ts
+++ b/tests/integration/container/tests/iam_authentication.test.ts
@@ -84,7 +84,9 @@ async function validateConnection(client: AwsPGClient | AwsMySQLClient) {
 describe("iam authentication", () => {
   beforeEach(async () => {
     logger.info(`Test started: ${expect.getState().currentTestName}`);
-    jest.useFakeTimers();
+    jest.useFakeTimers({
+      doNotFake: ["nextTick"]
+    });
     env = await TestEnvironment.getCurrent();
     driver = DriverHelper.getDriverForDatabaseEngine(env.engine);
     initClientFunc = DriverHelper.getClient(driver);
@@ -96,6 +98,11 @@ describe("iam authentication", () => {
     await TestEnvironment.verifyClusterStatus();
     logger.info(`Test finished: ${expect.getState().currentTestName}`);
   }, 1320000);
+
+  afterAll(async () => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
 
   itIf(
     "iam wrong database username",

--- a/tests/integration/container/tests/read_write_splitting.test.ts
+++ b/tests/integration/container/tests/read_write_splitting.test.ts
@@ -115,6 +115,7 @@ describe("aurora read write splitting", () => {
         // pass
       }
     }
+    await PluginManager.releaseResources();
     if (provider !== null) {
       try {
         await provider.releaseResources();
@@ -122,7 +123,6 @@ describe("aurora read write splitting", () => {
         // pass
       }
     }
-    await PluginManager.releaseResources();
     logger.info(`Test finished: ${expect.getState().currentTestName}`);
   }, 1320000);
 


### PR DESCRIPTION
### Summary

Updates integration tests. 

### Description

- Configures fakeTimers to not fake 'nextTick' for mysql to validate connection successfully. 
- Resets timers after all iam authentication tests. 
- Correctly orders the release of resources when a non default provider is used. 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
