### PR TITLE
More robust MySQL catalog usage detection

### DIFF
--- a/mysql/lib/dialect/mysql_database_dialect.ts
+++ b/mysql/lib/dialect/mysql_database_dialect.ts
@@ -195,8 +195,9 @@ export class MySQLDatabaseDialect implements DatabaseDialect {
   }
 
   doesStatementSetCatalog(statement: string): string | undefined {
-    if (statement.includes("use")) {
-      return statement.split(" ")[1];
+    const catalogRegexp = /^use\s+(\w+)/i;
+    if (catalogRegexp.test(statement)) {
+      return statement.split(catalogRegexp)[1];
     }
 
     return undefined;

--- a/tests/unit/sql_method_utils.test.ts
+++ b/tests/unit/sql_method_utils.test.ts
@@ -127,7 +127,9 @@ describe("test sql method utils", () => {
     [[" /* COMMENT */ select /* COMMENT */ 1 "], undefined],
     [[" use dbName "], "dbname"],
     [[" use/* COMMENT use dbName3*/ dbName "], "dbname"],
-    [[" use dbName1 ", " use dbName2 "], "dbname2"]
+    [[" use dbName1 ", " use dbName2 "], "dbname2"],
+    [[" select * from user", " select /* use dbName */ * from user "], undefined],
+    [[" use dbName; select 1"], "dbname"]
   ])("test catalog", (sql: string[], expectedResult: string | undefined) => {
     expect(SqlMethodUtils.doesSetCatalog(sql, new MySQLDatabaseDialect())).toBe(expectedResult);
   });


### PR DESCRIPTION
### Summary

The current MySQL catalog detection uses substring match to detect if a query makes use of a `USE` statement. The usage of substring match is brittle and fails if any part of the statement (other than a comment) has the substring `use`. 

This is problematic as `user` is a very common table name and gets mistakenly detected.

```ts
// Should return `undefined` but returns `"*"`
SqlMethodUtils.doesSetCatalog("select * from user", new MySQLDatabaseDialect()) // => "*"
```

### Description

This PR changes the substring match to a more robust regular expression. I also added a few tests cases.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
