### PR TITLE
refactor: remove dependency on RDS_CLUSTER_DOMAIN 

### DIFF
--- a/.github/workflows/aurora_performance.yml
+++ b/.github/workflows/aurora_performance.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           ./gradlew --no-parallel --no-daemon test-aurora-${{ matrix.db }}-performance --info
         env:
-          RDS_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
           RDS_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -63,7 +63,6 @@ jobs:
         run: |
           ./gradlew --no-parallel --no-daemon test-aurora-${{ matrix.dbEngine }} --info
         env:
-          RDS_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
           RDS_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration_tests_latest.yml
+++ b/.github/workflows/integration_tests_latest.yml
@@ -66,7 +66,6 @@ jobs:
         run: |
           ./gradlew --no-parallel --no-daemon test-aurora-${{ matrix.dbEngine }} --info
         env:
-          RDS_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
           RDS_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/multi_az_integration_tests.yml
+++ b/.github/workflows/multi_az_integration_tests.yml
@@ -63,7 +63,6 @@ jobs:
         run: |
           ./gradlew --no-parallel --no-daemon test-${{ matrix.dbEngine }} --info
         env:
-          RDS_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
           RDS_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/run-autoscaling-tests.yml
+++ b/.github/workflows/run-autoscaling-tests.yml
@@ -52,7 +52,6 @@ jobs:
         run: |
           ./gradlew --no-parallel --no-daemon test-autoscaling-${{ matrix.dbEngine }} --info
         env:
-          RDS_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
           RDS_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}

--- a/tests/integration/host/src/test/java/integration/host/TestEnvironmentConfig.java
+++ b/tests/integration/host/src/test/java/integration/host/TestEnvironmentConfig.java
@@ -242,10 +242,6 @@ public class TestEnvironmentConfig implements AutoCloseable {
     env.rdsMySqlDbEngineVersion = System.getenv("RDS_MYSQL_DB_ENGINE_VERSION"); // "latest", "default"
     env.rdsPgDbEngineVersion = System.getenv("RDS_PG_DB_ENGINE_VERSION");
 
-    if (StringUtils.isNullOrEmpty(env.auroraClusterDomain)) {
-      throw new RuntimeException("Environment variable RDS_CLUSTER_DOMAIN is required.");
-    }
-
     env.auroraUtil =
         new AuroraTestUtility(
             env.info.getRegion(),
@@ -257,6 +253,9 @@ public class TestEnvironmentConfig implements AutoCloseable {
     ArrayList<TestInstanceInfo> instances = new ArrayList<>();
 
     if (env.reuseAuroraDbCluster) {
+      if (StringUtils.isNullOrEmpty(env.auroraClusterDomain)) {
+        throw new RuntimeException("Environment variable RDS_CLUSTER_DOMAIN is required when testing against an existing Aurora DB cluster.");
+      }
       if (!env.auroraUtil.doesClusterExist(env.auroraClusterName)) {
         throw new RuntimeException(
             "It's requested to reuse existing DB cluster but it doesn't exist: "

--- a/tests/integration/host/src/test/java/integration/host/util/AuroraTestUtility.java
+++ b/tests/integration/host/src/test/java/integration/host/util/AuroraTestUtility.java
@@ -252,7 +252,7 @@ public class AuroraTestUtility {
                 builder.filters(
                     Filter.builder().name("db-cluster-id").values(dbIdentifier).build()));
     final String endpoint = dbInstancesResult.dbInstances().get(0).endpoint().address();
-    final String clusterDomainPrefix = endpoint.substring(endpoint.indexOf('.') + 1);
+    final String clusterDomainSuffix= endpoint.substring(endpoint.indexOf('.') + 1);
 
     for (DBInstance instance : dbInstancesResult.dbInstances()) {
       this.instances.add(
@@ -262,7 +262,7 @@ public class AuroraTestUtility {
               instance.endpoint().port()));
     }
 
-    return clusterDomainPrefix;
+    return clusterDomainSuffix;
   }
 
   /**
@@ -320,7 +320,7 @@ public class AuroraTestUtility {
                 builder.filters(
                     Filter.builder().name("db-cluster-id").values(dbIdentifier).build()));
     final String endpoint = dbInstancesResult.dbInstances().get(0).endpoint().address();
-    final String clusterDomainPrefix = endpoint.substring(endpoint.indexOf('.') + 1);
+    final String clusterDomainSuffix = endpoint.substring(endpoint.indexOf('.') + 1);
 
     for (DBInstance instance : dbInstancesResult.dbInstances()) {
       this.instances.add(
@@ -330,7 +330,7 @@ public class AuroraTestUtility {
               instance.endpoint().port()));
     }
 
-    return clusterDomainPrefix;
+    return clusterDomainSuffix;
   }
 
   /**

--- a/tests/integration/host/src/test/java/integration/host/util/AuroraTestUtility.java
+++ b/tests/integration/host/src/test/java/integration/host/util/AuroraTestUtility.java
@@ -252,7 +252,7 @@ public class AuroraTestUtility {
                 builder.filters(
                     Filter.builder().name("db-cluster-id").values(dbIdentifier).build()));
     final String endpoint = dbInstancesResult.dbInstances().get(0).endpoint().address();
-    final String clusterDomainSuffix= endpoint.substring(endpoint.indexOf('.') + 1);
+    final String clusterDomainSuffix = endpoint.substring(endpoint.indexOf('.') + 1);
 
     for (DBInstance instance : dbInstancesResult.dbInstances()) {
       this.instances.add(


### PR DESCRIPTION
### Summary

refactor: move check for RDS_CLUSTER_DOMAIN so only tests running against existing clusters need to provide this env variable

### Description

When testing against new clusters the driver ignores the value specified by `RDS_CLUSTER_DOMAIN`, so the automated integration tests don't actually need this env present.

Test run: https://github.com/aws/aws-advanced-nodejs-wrapper/actions/runs/12820242029

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
