### PR TITLE
chore: update toxiproxy remove proxy

### DIFF
--- a/tests/integration/container/tests/utils/proxy_helper.ts
+++ b/tests/integration/container/tests/utils/proxy_helper.ts
@@ -70,10 +70,14 @@ export class ProxyHelper {
     const proxy = proxyInfo.proxy;
 
     if (proxy !== undefined) {
-      const toxics = proxy.toxics;
-      toxics.forEach((toxic) => {
-        toxic.remove();
-      });
+      try {
+        const upstreamToxic = await proxy.getToxic("UP-STREAM");
+        await upstreamToxic.remove();
+        const downstreamToxic = await proxy.getToxic("DOWN-STREAM");
+        await downstreamToxic.remove();
+      } catch (e) {
+        // Ignore
+      }
     }
   }
 }


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

`Proxy.toxics` was removed from toxiproxy-node-client in version 4.0.0, this PR adjusts the proxy helper class within the integration tests to account for this change.

Actions test run: https://github.com/aws/aws-advanced-nodejs-wrapper/actions/runs/12938784886

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
