### PR TITLE
refactor: sliding expiration cache with cleanup task

### DIFF
--- a/common/lib/host_list_provider/monitoring/monitoring_host_list_provider.ts
+++ b/common/lib/host_list_provider/monitoring/monitoring_host_list_provider.ts
@@ -16,7 +16,6 @@
 
 import { RdsHostListProvider } from "../rds_host_list_provider";
 import { HostInfo } from "../../host_info";
-import { SlidingExpirationCache } from "../../utils/sliding_expiration_cache";
 import { ClusterTopologyMonitor, ClusterTopologyMonitorImpl } from "./cluster_topology_monitor";
 import { PluginService } from "../../plugin_service";
 import { HostListProviderService } from "../../host_list_provider_service";
@@ -44,7 +43,8 @@ export class MonitoringRdsHostListProvider extends RdsHostListProvider implement
       } catch {
         // Ignore.
       }
-    }
+    },
+    "MonitoringRdsHostListProvider.monitors"
   );
 
   private readonly pluginService: PluginService;

--- a/common/lib/internal_pooled_connection_provider.ts
+++ b/common/lib/internal_pooled_connection_provider.ts
@@ -17,7 +17,6 @@
 import { PluginService } from "./plugin_service";
 import { WrapperProperties } from "./wrapper_property";
 import { CanReleaseResources } from "./can_release_resources";
-import { SlidingExpirationCache } from "./utils/sliding_expiration_cache";
 import { PoolKey } from "./utils/pool_key";
 import { PooledConnectionProvider } from "./pooled_connection_provider";
 import { HostInfo } from "./host_info";
@@ -39,14 +38,15 @@ import { AwsPoolConfig } from "./aws_pool_config";
 import { LeastConnectionsHostSelector } from "./least_connections_host_selector";
 import { PoolClientWrapper } from "./pool_client_wrapper";
 import { logger } from "../logutils";
+import { SlidingExpirationCacheWithCleanupTask } from "./utils/sliding_expiration_cache_with_cleanup_task";
 
 export class InternalPooledConnectionProvider implements PooledConnectionProvider, CanReleaseResources {
   static readonly CACHE_CLEANUP_NANOS: bigint = BigInt(10 * 60_000_000_000); // 10 minutes
   static readonly POOL_EXPIRATION_NANOS: bigint = BigInt(30 * 60_000_000_000); // 30 minutes
-  protected static databasePools: SlidingExpirationCache<string, any> = new SlidingExpirationCache(
+  protected static databasePools: SlidingExpirationCacheWithCleanupTask<string, AwsPoolClient> = new SlidingExpirationCacheWithCleanupTask(
     InternalPooledConnectionProvider.CACHE_CLEANUP_NANOS,
-    (pool: any) => pool.getActiveCount() === 0,
-    (pool: any) => pool.end()
+    (pool: AwsPoolClient) => pool.getActiveCount() === 0,
+    async (pool: AwsPoolClient) => await pool.end()
   );
 
   private static readonly acceptedStrategies: Map<string, HostSelector> = new Map([
@@ -122,16 +122,7 @@ export class InternalPooledConnectionProvider implements PooledConnectionProvide
   }
 
   async releaseResources() {
-    for (const [_key, value] of InternalPooledConnectionProvider.databasePools.entries) {
-      if (value.item) {
-        await value.item.releaseResources();
-      }
-    }
-    InternalPooledConnectionProvider.clearDatabasePools();
-  }
-
-  static clearDatabasePools() {
-    InternalPooledConnectionProvider.databasePools.clear();
+    await InternalPooledConnectionProvider.databasePools.clear();
   }
 
   getHostInfoByStrategy(hosts: HostInfo[], role: HostRole, strategy: string, props?: Map<string, any>): HostInfo {
@@ -177,7 +168,7 @@ export class InternalPooledConnectionProvider implements PooledConnectionProvide
   }
 
   // for testing only
-  setDatabasePools(connectionPools: SlidingExpirationCache<string, any>): void {
+  setDatabasePools(connectionPools: SlidingExpirationCacheWithCleanupTask<string, any>): void {
     InternalPooledConnectionProvider.databasePools = connectionPools;
     LeastConnectionsHostSelector.setDatabasePools(connectionPools);
   }

--- a/common/lib/internal_pooled_connection_provider.ts
+++ b/common/lib/internal_pooled_connection_provider.ts
@@ -43,10 +43,11 @@ import { SlidingExpirationCacheWithCleanupTask } from "./utils/sliding_expiratio
 export class InternalPooledConnectionProvider implements PooledConnectionProvider, CanReleaseResources {
   static readonly CACHE_CLEANUP_NANOS: bigint = BigInt(10 * 60_000_000_000); // 10 minutes
   static readonly POOL_EXPIRATION_NANOS: bigint = BigInt(30 * 60_000_000_000); // 30 minutes
-  protected static databasePools: SlidingExpirationCacheWithCleanupTask<string, AwsPoolClient> = new SlidingExpirationCacheWithCleanupTask(
+  protected static databasePools: SlidingExpirationCacheWithCleanupTask<string, any> = new SlidingExpirationCacheWithCleanupTask(
     InternalPooledConnectionProvider.CACHE_CLEANUP_NANOS,
-    (pool: AwsPoolClient) => pool.getActiveCount() === 0,
-    async (pool: AwsPoolClient) => await pool.end()
+    (pool: any) => pool.getActiveCount() === 0,
+    async (pool: any) => await pool.end(),
+    "InternalPooledConnectionProvider.databasePools"
   );
 
   private static readonly acceptedStrategies: Map<string, HostSelector> = new Map([

--- a/common/lib/plugins/efm/host_monitoring_connection_plugin.ts
+++ b/common/lib/plugins/efm/host_monitoring_connection_plugin.ts
@@ -203,6 +203,6 @@ export class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin imp
   }
 
   async releaseResources(): Promise<void> {
-    return this.monitorService.releaseResources();
+    await this.monitorService.releaseResources();
   }
 }

--- a/common/lib/plugins/efm/monitor_service.ts
+++ b/common/lib/plugins/efm/monitor_service.ts
@@ -50,7 +50,7 @@ export class MonitorServiceImpl implements MonitorService {
     async (monitor: Monitor) => {
       await monitor.releaseResources();
     },
-    "MonitorServiceImpl.monitors"
+    "efm/MonitorServiceImpl.monitors"
   );
   private readonly pluginService: PluginService;
   private cachedMonitorHostKeys: Set<string> | undefined;

--- a/common/lib/plugins/efm/monitor_service.ts
+++ b/common/lib/plugins/efm/monitor_service.ts
@@ -49,7 +49,8 @@ export class MonitorServiceImpl implements MonitorService {
     undefined,
     async (monitor: Monitor) => {
       await monitor.releaseResources();
-    }
+    },
+    "MonitorServiceImpl.monitors"
   );
   private readonly pluginService: PluginService;
   private cachedMonitorHostKeys: Set<string> | undefined;

--- a/common/lib/plugins/efm/monitor_service.ts
+++ b/common/lib/plugins/efm/monitor_service.ts
@@ -19,9 +19,9 @@ import { HostInfo } from "../../host_info";
 import { AwsWrapperError, IllegalArgumentError } from "../../utils/errors";
 import { Monitor, MonitorImpl } from "./monitor";
 import { WrapperProperties } from "../../wrapper_property";
-import { SlidingExpirationCache } from "../../utils/sliding_expiration_cache";
 import { PluginService } from "../../plugin_service";
 import { Messages } from "../../utils/messages";
+import { SlidingExpirationCacheWithCleanupTask } from "../../utils/sliding_expiration_cache_with_cleanup_task";
 import { ClientWrapper } from "../../client_wrapper";
 
 export interface MonitorService {
@@ -44,10 +44,12 @@ export interface MonitorService {
 
 export class MonitorServiceImpl implements MonitorService {
   private static readonly CACHE_CLEANUP_NANOS = BigInt(60_000_000_000);
-  protected static readonly monitors: SlidingExpirationCache<string, Monitor> = new SlidingExpirationCache(
+  protected static readonly monitors: SlidingExpirationCacheWithCleanupTask<string, Monitor> = new SlidingExpirationCacheWithCleanupTask(
     MonitorServiceImpl.CACHE_CLEANUP_NANOS,
     undefined,
-    () => {}
+    async (monitor: Monitor) => {
+      await monitor.releaseResources();
+    }
   );
   private readonly pluginService: PluginService;
   private cachedMonitorHostKeys: Set<string> | undefined;
@@ -108,7 +110,7 @@ export class MonitorServiceImpl implements MonitorService {
   }
 
   stopMonitoringForAllConnections(hostKeys: Set<string>) {
-    let monitor;
+    let monitor: Monitor;
     for (const hostKey of hostKeys) {
       monitor = MonitorServiceImpl.monitors.get(hostKey);
       if (monitor) {
@@ -119,8 +121,8 @@ export class MonitorServiceImpl implements MonitorService {
   }
 
   async getMonitor(hostKeys: Set<string>, hostInfo: HostInfo, properties: Map<string, any>): Promise<Monitor | null> {
-    let monitor;
-    let anyHostKey;
+    let monitor: Monitor;
+    let anyHostKey: string;
     for (const hostKey of hostKeys) {
       monitor = MonitorServiceImpl.monitors.get(hostKey);
       anyHostKey = hostKey;
@@ -159,16 +161,13 @@ export class MonitorServiceImpl implements MonitorService {
   }
 
   async releaseResources() {
-    for (const [_key, monitor] of MonitorServiceImpl.monitors.entries) {
-      if (monitor.item) {
-        await monitor.item.releaseResources();
-      }
-    }
+    await MonitorServiceImpl.monitors.clear();
     this.cachedMonitorHostKeys = undefined;
     this.cachedMonitorRef = undefined;
   }
 
-  static clearMonitors() {
-    MonitorServiceImpl.monitors.clear();
+  // Used for performance testing.
+  static async clearMonitors() {
+    await MonitorServiceImpl.monitors.clear();
   }
 }

--- a/common/lib/plugins/efm2/host_monitoring2_connection_plugin.ts
+++ b/common/lib/plugins/efm2/host_monitoring2_connection_plugin.ts
@@ -171,6 +171,6 @@ export class HostMonitoring2ConnectionPlugin extends AbstractConnectionPlugin im
   }
 
   async releaseResources(): Promise<void> {
-    return this.monitorService.releaseResources();
+    await this.monitorService.releaseResources();
   }
 }

--- a/common/lib/plugins/limitless/limitless_router_service.ts
+++ b/common/lib/plugins/limitless/limitless_router_service.ts
@@ -31,6 +31,7 @@ import { HostRole } from "../../host_role";
 import { HostAvailability } from "../../host_availability/host_availability";
 import { HighestWeightHostSelector } from "../../highest_weight_host_selector";
 import { sleep } from "../../utils/utils";
+import { SlidingExpirationCacheWithCleanupTask } from "../../utils/sliding_expiration_cache_with_cleanup_task";
 
 export interface LimitlessRouterService {
   startMonitor(hostInfo: HostInfo, properties: Map<string, any>): void;
@@ -40,11 +41,12 @@ export interface LimitlessRouterService {
 
 export class LimitlessRouterServiceImpl implements LimitlessRouterService {
   protected static readonly CACHE_CLEANUP_NANOS = BigInt(60_000_000_000); // 1 min
-  protected static readonly monitors: SlidingExpirationCache<string, LimitlessRouterMonitor> = new SlidingExpirationCache(
-    LimitlessRouterServiceImpl.CACHE_CLEANUP_NANOS,
-    undefined,
-    async (monitor) => await monitor.close()
-  );
+  protected static readonly monitors: SlidingExpirationCacheWithCleanupTask<string, LimitlessRouterMonitor> =
+    new SlidingExpirationCacheWithCleanupTask(
+      LimitlessRouterServiceImpl.CACHE_CLEANUP_NANOS,
+      undefined,
+      async (monitor: LimitlessRouterMonitor) => await monitor.close()
+    );
   protected static readonly limitlessRouterCache: SlidingExpirationCache<string, HostInfo[]> = new SlidingExpirationCache(
     LimitlessRouterServiceImpl.CACHE_CLEANUP_NANOS,
     undefined,
@@ -254,7 +256,7 @@ export class LimitlessRouterServiceImpl implements LimitlessRouterService {
     }
   }
 
-  static clearMonitors() {
-    LimitlessRouterServiceImpl.monitors.clear();
+  static async clearMonitors() {
+    await LimitlessRouterServiceImpl.monitors.clear();
   }
 }

--- a/common/lib/plugins/limitless/limitless_router_service.ts
+++ b/common/lib/plugins/limitless/limitless_router_service.ts
@@ -45,7 +45,8 @@ export class LimitlessRouterServiceImpl implements LimitlessRouterService {
     new SlidingExpirationCacheWithCleanupTask(
       LimitlessRouterServiceImpl.CACHE_CLEANUP_NANOS,
       undefined,
-      async (monitor: LimitlessRouterMonitor) => await monitor.close()
+      async (monitor: LimitlessRouterMonitor) => await monitor.close(),
+      "LimitlessRouterServiceImpl.monitors"
     );
   protected static readonly limitlessRouterCache: SlidingExpirationCache<string, HostInfo[]> = new SlidingExpirationCache(
     LimitlessRouterServiceImpl.CACHE_CLEANUP_NANOS,

--- a/common/lib/plugins/strategy/fastest_response/host_response_time_service.ts
+++ b/common/lib/plugins/strategy/fastest_response/host_response_time_service.ts
@@ -45,7 +45,7 @@ export class HostResponseTimeServiceImpl implements HostResponseTimeService {
   readonly intervalMs: number;
   protected hosts: HostInfo[];
   private readonly telemetryFactory: TelemetryFactory;
-  protected static monitoringHosts: SlidingExpirationCache<string, any> = new SlidingExpirationCache(
+  protected static monitoringHosts: SlidingExpirationCache<string, HostResponseTimeMonitor> = new SlidingExpirationCache(
     HostResponseTimeServiceImpl.CACHE_CLEANUP_NANOS,
     undefined,
     async (monitor: HostResponseTimeMonitor) => {

--- a/common/lib/utils/locales/en.json
+++ b/common/lib/utils/locales/en.json
@@ -248,4 +248,7 @@
   "CustomEndpointMonitorImpl.stoppingMonitor": "Stopping custom endpoint monitor for '%s'.",
   "CustomEndpointMonitorImpl.noEndpoints": "Unable to find any custom endpoints. When connecting with a custom endpoint, at least one custom endpoint should be detected.",
   "AwsSdk.unsupportedRegion": "Unsupported AWS region '%s'. For supported regions please read https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html"
+  "HostMonitor.writerHostChanged": "Writer host has changed from '%s' to '%s'.",
+  "SlidingExpirationCacheWithCleanupTask.cleaningUp": "Cleanup interval of '%s' minutes has passed, cleaning up sliding expiration cache.",
+  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskInterrupted": "Cleanup task has been interrupted and is exiting."
 }

--- a/common/lib/utils/locales/en.json
+++ b/common/lib/utils/locales/en.json
@@ -233,6 +233,11 @@
   "HostMonitor.detectedWriter": "Detected writer: '%s'.",
   "HostMonitor.endMonitoring": "Host monitor '%s' completed in '%s'.",
   "HostMonitor.writerHostChanged": "Writer host has changed from '%s' to '%s'.",
+  "SlidingExpirationCacheWithCleanupTask.cleaningUp": "Cleanup interval of '%s' minutes has passed, cleaning up sliding expiration cache '%s'.",
+  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskInterrupted": "Sliding expiration cache '%s' cleanup task has been interrupted and is exiting.",
+  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskStopped": "Sliding expiration cache '%s' cleanup task has been stopped and is exiting.",
+  "SlidingExpirationCacheWithCleanupTask.clear": "Sliding expiration cache '%s' has been cleared, all resources are released.",
+  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskInitialized": "Sliding expiration cache '%s' cleanup task has been initialized.",
   "HostMonitoringConnectionPlugin.monitoringDeactivated": "Monitoring deactivated for method '%s'.",
   "CustomEndpointPlugin.connectionRequestToCustomEndpoint": "Detected a connection request to a custom endpoint URL: '%s'.",
   "CustomEndpointPlugin.errorParsingEndpointIdentifier": "Unable to parse custom endpoint identifier from URL: '%s'.",
@@ -248,10 +253,4 @@
   "CustomEndpointMonitorImpl.stoppingMonitor": "Stopping custom endpoint monitor for '%s'.",
   "CustomEndpointMonitorImpl.noEndpoints": "Unable to find any custom endpoints. When connecting with a custom endpoint, at least one custom endpoint should be detected.",
   "AwsSdk.unsupportedRegion": "Unsupported AWS region '%s'. For supported regions please read https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html"
-  "HostMonitor.writerHostChanged": "Writer host has changed from '%s' to '%s'.",
-  "SlidingExpirationCacheWithCleanupTask.cleaningUp": "Cleanup interval of '%s' minutes has passed, cleaning up sliding expiration cache '%s'.",
-  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskInterrupted": "Sliding expiration cache '%s' cleanup task has been interrupted and is exiting.",
-  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskStopped": "Sliding expiration cache '%s' cleanup task has been stopped and is exiting.",
-  "SlidingExpirationCacheWithCleanupTask.clear": "Sliding expiration cache '%s' is being cleared, all resources will be released.",
-  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskInitialized": "Sliding expiration cache '%s' cleanup task has been initialized."
 }

--- a/common/lib/utils/locales/en.json
+++ b/common/lib/utils/locales/en.json
@@ -249,6 +249,9 @@
   "CustomEndpointMonitorImpl.noEndpoints": "Unable to find any custom endpoints. When connecting with a custom endpoint, at least one custom endpoint should be detected.",
   "AwsSdk.unsupportedRegion": "Unsupported AWS region '%s'. For supported regions please read https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html"
   "HostMonitor.writerHostChanged": "Writer host has changed from '%s' to '%s'.",
-  "SlidingExpirationCacheWithCleanupTask.cleaningUp": "Cleanup interval of '%s' minutes has passed, cleaning up sliding expiration cache.",
-  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskInterrupted": "Cleanup task has been interrupted and is exiting."
+  "SlidingExpirationCacheWithCleanupTask.cleaningUp": "Cleanup interval of '%s' minutes has passed, cleaning up sliding expiration cache '%s'.",
+  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskInterrupted": "Sliding expiration cache '%s' cleanup task has been interrupted and is exiting.",
+  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskStopped": "Sliding expiration cache '%s' cleanup task has been stopped and is exiting.",
+  "SlidingExpirationCacheWithCleanupTask.clear": "Sliding expiration cache '%s' is being cleared, all resources will be released.",
+  "SlidingExpirationCacheWithCleanupTask.cleanUpTaskInitialized": "Sliding expiration cache '%s' cleanup task has been initialized."
 }

--- a/common/lib/utils/sliding_expiration_cache.ts
+++ b/common/lib/utils/sliding_expiration_cache.ts
@@ -37,7 +37,7 @@ class CacheItem<V> {
 }
 
 export class SlidingExpirationCache<K, V> {
-  private _cleanupIntervalNanos: bigint = BigInt(10 * 60_000_000_000); // 10 minutes
+  protected _cleanupIntervalNanos: bigint = BigInt(10 * 60_000_000_000); // 10 minutes
   private readonly _shouldDisposeFunc?: (item: V) => boolean;
   private readonly _itemDisposalFunc?: (item: V) => void;
   map: Map<K, CacheItem<V>> = new Map<K, CacheItem<V>>();
@@ -116,7 +116,7 @@ export class SlidingExpirationCache<K, V> {
       return cacheItem;
     });
 
-    if (item != undefined && item != null && this._itemDisposalFunc != null) {
+    if (item != undefined && this._itemDisposalFunc != null) {
       this._itemDisposalFunc(item);
     }
   }

--- a/common/lib/utils/sliding_expiration_cache_with_cleanup_task.ts
+++ b/common/lib/utils/sliding_expiration_cache_with_cleanup_task.ts
@@ -1,0 +1,106 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { convertNanosToMinutes, convertNanosToMs, sleepWithAbort } from "./utils";
+import { MapUtils } from "./map_utils";
+import { SlidingExpirationCache } from "./sliding_expiration_cache";
+import { Messages } from "./messages";
+import { logger } from "../../logutils";
+
+export class SlidingExpirationCacheWithCleanupTask<K, V> extends SlidingExpirationCache<K, V> {
+  private readonly _asyncItemDisposalFunc?: (item: V) => Promise<void>;
+  private stopCleanupTask: boolean = false;
+  private cleanupTask: Promise<void>;
+  private interruptCleanupTask: () => void;
+  private isInitialized: boolean = false;
+
+  constructor(cleanupIntervalNanos: bigint, shouldDisposeFunc?: (item: V) => boolean, asyncItemDisposalFunc?: (item: V) => Promise<void>) {
+    super(cleanupIntervalNanos, shouldDisposeFunc);
+    this._asyncItemDisposalFunc = asyncItemDisposalFunc;
+  }
+
+  async clear(): Promise<void> {
+    this.stopCleanupTask = true;
+    // If the cleanup task is currently sleeping this will interrupt it.
+    this.interruptCleanupTask();
+    await this.cleanupTask;
+
+    for (const [key, val] of this.map.entries()) {
+      if (val !== undefined && this._asyncItemDisposalFunc !== undefined) {
+        await this._asyncItemDisposalFunc(val.item);
+      }
+    }
+    this.map.clear();
+  }
+
+  computeIfAbsent(key: K, mappingFunc: (key: K) => V, itemExpirationNanos: bigint): V | null {
+    if (!this.isInitialized) {
+      this.cleanupTask = this.initCleanupTask();
+    }
+    return super.computeIfAbsent(key, mappingFunc, itemExpirationNanos);
+  }
+
+  putIfAbsent(key: K, value: V, itemExpirationNanos: bigint): V | null {
+    if (!this.isInitialized) {
+      this.cleanupTask = this.initCleanupTask();
+    }
+    return super.putIfAbsent(key, value, itemExpirationNanos);
+  }
+
+  put(key: K, value: V, itemExpirationNanos: bigint): V | null {
+    if (!this.isInitialized) {
+      this.cleanupTask = this.initCleanupTask();
+    }
+    return super.put(key, value, itemExpirationNanos);
+  }
+
+  protected cleanUp(): void {
+    // Intentionally does nothing, cleanup task performs this job.
+  }
+
+  async initCleanupTask(): Promise<void> {
+    this.isInitialized = true;
+    while (!this.stopCleanupTask) {
+      const [sleepPromise, temp] = sleepWithAbort(
+        convertNanosToMs(this._cleanupIntervalNanos),
+        Messages.get("SlidingExpirationCacheWithCleanupTask.cleanUpTaskInterrupted")
+      );
+      this.interruptCleanupTask = temp;
+      try {
+        await sleepPromise;
+      } catch (error) {
+        // Sleep has been interrupted, exit cleanup task.
+        logger.info(error.message);
+        return;
+      }
+
+      logger.info(Messages.get("SlidingExpirationCacheWithCleanupTask.cleaningUp", convertNanosToMinutes(this._cleanupIntervalNanos).toString()));
+
+      const itemsToRemove = [];
+      for (const [key, val] of this.map.entries()) {
+        if (val !== undefined && this._asyncItemDisposalFunc !== undefined && this.shouldCleanupItem(val)) {
+          MapUtils.remove(this.map, key);
+          itemsToRemove.push(this._asyncItemDisposalFunc(val.item));
+        }
+      }
+      try {
+        await Promise.all(itemsToRemove);
+      } catch (error) {
+        // Ignore.
+      }
+    }
+  }
+}

--- a/common/lib/utils/utils.ts
+++ b/common/lib/utils/utils.ts
@@ -26,6 +26,18 @@ export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export function sleepWithAbort(ms: number, message?: string) {
+  let abortSleep;
+  const promise = new Promise((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms);
+    abortSleep = () => {
+      clearTimeout(timeout);
+      reject(new AwsWrapperError(message));
+    };
+  });
+  return [promise, abortSleep];
+}
+
 export function getTimeoutTask(timer: any, message: string, timeoutValue: number): Promise<void> {
   return new Promise((_resolve, reject) => {
     timer.timeoutId = setTimeout(() => {
@@ -55,6 +67,14 @@ export function logTopology(hosts: HostInfo[], msgPrefix: string) {
 
 export function getTimeInNanos() {
   return process.hrtime.bigint();
+}
+
+export function convertNanosToMs(nanos: bigint) {
+  return Number(nanos) / 1000000;
+}
+
+export function convertNanosToMinutes(nanos: bigint) {
+  return Number(nanos) / 60000000000;
 }
 
 export function maskProperties(props: Map<string, any>) {

--- a/tests/integration/container/tests/performance.test.ts
+++ b/tests/integration/container/tests/performance.test.ts
@@ -219,7 +219,7 @@ async function doMeasurePerformance(sleepDelayMillis: number, repeatTimes: numbe
       try {
         await ProxyHelper.enableAllConnectivity();
         await client.end();
-        MonitorServiceImpl.clearMonitors();
+        await MonitorServiceImpl.clearMonitors();
       } catch (error: any) {
         // ignore
       }

--- a/tests/integration/container/tests/read_write_splitting.test.ts
+++ b/tests/integration/container/tests/read_write_splitting.test.ts
@@ -547,6 +547,7 @@ describe("aurora read write splitting", () => {
         await auroraTestUtility.queryInstanceId(client);
       }).rejects.toThrow(FailoverFailedError);
       await ProxyHelper.enableAllConnectivity();
+      await client.end();
       await client.connect();
       await TestEnvironment.verifyClusterStatus();
 

--- a/tests/unit/aws_client_get_plugin_instance.test.ts
+++ b/tests/unit/aws_client_get_plugin_instance.test.ts
@@ -20,6 +20,7 @@ import { DeveloperConnectionPlugin } from "../../common/lib/plugins/dev/develope
 import { RdsUtils } from "../../common/lib/utils/rds_utils";
 import { AwsPGClient } from "../../pg/lib";
 import { IamAuthenticationPlugin } from "../../common/lib/authentication/iam_authentication_plugin";
+import { Messages } from "../../common/lib/utils/messages";
 
 class DevPluginTest extends DeveloperConnectionPlugin {
   testMethod() {
@@ -59,7 +60,7 @@ describe("testGetPluginInstance", () => {
       testClient.getPluginInstance(IamAuthenticationPlugin);
       throw new Error("Retrieved plugin instance of wrong type.");
     } catch (error: any) {
-      expect(error.message).toEqual("Unable to retrieve plugin instance.");
+      expect(error.message).toEqual(Messages.get("PluginManager.unableToRetrievePlugin"));
     }
   });
 });

--- a/tests/unit/monitor_service_impl.test.ts
+++ b/tests/unit/monitor_service_impl.test.ts
@@ -57,6 +57,10 @@ describe("monitor service impl test", () => {
     monitorService.monitorSupplier = () => new MonitorImplTest(instance(mockPluginService), instance(mockHostInfo), properties, 0);
   });
 
+  afterEach(async () => {
+    await monitorService.releaseResources();
+  });
+
   it("start monitoring", async () => {
     monitorService.monitorSupplier = () => instance(mockMonitorA);
 

--- a/tests/unit/reader_failover_handler.test.ts
+++ b/tests/unit/reader_failover_handler.test.ts
@@ -252,16 +252,23 @@ describe("reader failover handler", () => {
   });
 
   it("test get reader connection attempts timeout", async () => {
-    // connection attempts time out before they can succeed
-    // first connection attempt to return times out
-    // expected test result: failure to get reader
-    let timeoutId: any = -1;
-    const hosts = [host1, host2, host3]; // 2 connection attempts (writer not attempted)
+    // Connection attempts time out before they can succeed.
+    // First connection attempt to return times out.
+    // Expected test result: failure to get reader.
+    let timeoutId2: any = -1;
+    let timeoutId3: any = -1;
+    const hosts = [host1, host2, host3]; // 2 connection attempts of host2 and host 3 (host1 is a writer and not attempted).
 
     when(mockPluginService.getHosts()).thenReturn(hosts);
-    when(mockPluginService.forceConnect(anything(), anything())).thenCall(async () => {
-      await new Promise((resolve, reject) => {
-        timeoutId = setTimeout(resolve, 10000);
+    when(mockPluginService.forceConnect(host2, anything())).thenCall(async () => {
+      await new Promise((resolve) => {
+        timeoutId2 = setTimeout(resolve, 10000);
+      });
+      return;
+    });
+    when(mockPluginService.forceConnect(host3, anything())).thenCall(async () => {
+      await new Promise((resolve) => {
+        timeoutId3 = setTimeout(resolve, 10000);
       });
       return;
     });
@@ -279,7 +286,8 @@ describe("reader failover handler", () => {
     expect(result.isConnected).toBe(false);
     expect(result.client).toBe(null);
     expect(result.newHost).toBe(null);
-    clearTimeout(timeoutId);
+    clearTimeout(timeoutId2);
+    clearTimeout(timeoutId3);
   }, 10000);
 
   it("test get host tuples by priority", async () => {

--- a/tests/unit/sliding_expiration_cache.test.ts
+++ b/tests/unit/sliding_expiration_cache.test.ts
@@ -63,6 +63,7 @@ describe("test_sliding_expiration_cache", () => {
     expect(result3).toEqual("b");
     expect(target.get(1)).toEqual("b");
   });
+
   it("test remove", async () => {
     const target = new SlidingExpirationCache(
       BigInt(50_000_000),
@@ -100,6 +101,7 @@ describe("test_sliding_expiration_cache", () => {
     expect(target.get("nonExpiredItem")).toEqual(nonExpiredItem);
     expect(nonExpiredItem.disposed).toEqual(false);
   });
+
   it("test clear", async () => {
     const target = new SlidingExpirationCache(
       BigInt(50_000_000),
@@ -124,13 +126,15 @@ describe("test_sliding_expiration_cache", () => {
     expect(item1.disposed).toEqual(true);
     expect(item2.disposed).toEqual(true);
   });
+
   it("test async cleanup thread", async () => {
     const cleanupIntervalNanos = BigInt(300_000_000); // .3 seconds
     const disposeMs = 1000;
     const target = new SlidingExpirationCacheWithCleanupTask(
       cleanupIntervalNanos,
       (item: AsyncDisposableItem) => item.shouldDispose,
-      async (item) => await item.dispose(disposeMs)
+      async (item) => await item.dispose(disposeMs),
+      "slidingExpirationCache.test"
     );
     const item1 = new AsyncDisposableItem(true);
     const item2 = new AsyncDisposableItem(false);
@@ -161,11 +165,13 @@ describe("test_sliding_expiration_cache", () => {
     expect(target.get(2)).toEqual(undefined);
     expect(item2.disposed).toEqual(true);
   });
+
   it("test async clear", async () => {
     const target = new SlidingExpirationCacheWithCleanupTask(
       BigInt(50_000_000),
       (item: AsyncDisposableItem) => item.shouldDispose,
-      async (item) => await item.dispose(1000)
+      async (item) => await item.dispose(1000),
+      "slidingExpirationCache.test"
     );
     const item1 = new AsyncDisposableItem(false);
     const item2 = new AsyncDisposableItem(false);

--- a/tests/unit/sliding_expiration_cache.test.ts
+++ b/tests/unit/sliding_expiration_cache.test.ts
@@ -15,7 +15,8 @@
 */
 
 import { SlidingExpirationCache } from "../../common/lib/utils/sliding_expiration_cache";
-import { sleep } from "../../common/lib/utils/utils";
+import { convertNanosToMs, sleep } from "../../common/lib/utils/utils";
+import { SlidingExpirationCacheWithCleanupTask } from "../../common/lib/utils/sliding_expiration_cache_with_cleanup_task";
 
 class DisposableItem {
   shouldDispose: boolean;
@@ -30,8 +31,22 @@ class DisposableItem {
   }
 }
 
+class AsyncDisposableItem {
+  shouldDispose: boolean;
+  disposed: boolean;
+  constructor(shouldDispose: boolean) {
+    this.shouldDispose = shouldDispose;
+    this.disposed = false;
+  }
+
+  async dispose(disposalTimeMs: number): Promise<void> {
+    await sleep(disposalTimeMs);
+    this.disposed = true;
+  }
+}
+
 describe("test_sliding_expiration_cache", () => {
-  it("test_compute_if_absent", async () => {
+  it("test compute if absent", async () => {
     const target = new SlidingExpirationCache(BigInt(50_000_000));
     const result1 = target.computeIfAbsent(1, () => "a", BigInt(1));
     const originalItemExpiration = target.map.get(1)!.expirationTimeNs;
@@ -48,7 +63,7 @@ describe("test_sliding_expiration_cache", () => {
     expect(result3).toEqual("b");
     expect(target.get(1)).toEqual("b");
   });
-  it("test_remove", async () => {
+  it("test remove", async () => {
     const target = new SlidingExpirationCache(
       BigInt(50_000_000),
       (item: DisposableItem) => item.shouldDispose,
@@ -85,7 +100,7 @@ describe("test_sliding_expiration_cache", () => {
     expect(target.get("nonExpiredItem")).toEqual(nonExpiredItem);
     expect(nonExpiredItem.disposed).toEqual(false);
   });
-  it("test_clear", async () => {
+  it("test clear", async () => {
     const target = new SlidingExpirationCache(
       BigInt(50_000_000),
       (item: DisposableItem) => item.shouldDispose,
@@ -102,6 +117,67 @@ describe("test_sliding_expiration_cache", () => {
     expect(target.get(2)).toEqual(item2);
 
     target.clear();
+
+    expect(target.size).toEqual(0);
+    expect(target.get(1)).toEqual(undefined);
+    expect(target.get(2)).toEqual(undefined);
+    expect(item1.disposed).toEqual(true);
+    expect(item2.disposed).toEqual(true);
+  });
+  it("test async cleanup thread", async () => {
+    const cleanupIntervalNanos = BigInt(300_000_000); // .3 seconds
+    const disposeMs = 1000;
+    const target = new SlidingExpirationCacheWithCleanupTask(
+      cleanupIntervalNanos,
+      (item: AsyncDisposableItem) => item.shouldDispose,
+      async (item) => await item.dispose(disposeMs)
+    );
+    const item1 = new AsyncDisposableItem(true);
+    const item2 = new AsyncDisposableItem(false);
+
+    target.computeIfAbsent(1, () => item1, BigInt(100_000_000)); // .1 seconds
+    target.computeIfAbsent(2, () => item2, BigInt(15_000_000_000));
+
+    expect(target.size).toEqual(2);
+    expect(target.get(1)).toEqual(item1);
+    expect(target.get(2)).toEqual(item2);
+
+    // Item should be removed by the cleanup task after cleanupIntervalNanos have passed.
+    await sleep(convertNanosToMs(cleanupIntervalNanos));
+
+    expect(target.size).toEqual(1);
+    expect(target.get(1)).toEqual(undefined);
+    expect(target.get(2)).toEqual(item2);
+
+    // Item will be cleaned up after disposalMs have passed.
+    await sleep(disposeMs);
+
+    expect(item1.disposed).toEqual(true);
+    expect(item2.disposed).toEqual(false);
+
+    await target.clear();
+
+    expect(target.size).toEqual(0);
+    expect(target.get(2)).toEqual(undefined);
+    expect(item2.disposed).toEqual(true);
+  });
+  it("test async clear", async () => {
+    const target = new SlidingExpirationCacheWithCleanupTask(
+      BigInt(50_000_000),
+      (item: AsyncDisposableItem) => item.shouldDispose,
+      async (item) => await item.dispose(1000)
+    );
+    const item1 = new AsyncDisposableItem(false);
+    const item2 = new AsyncDisposableItem(false);
+
+    target.computeIfAbsent(1, () => item1, BigInt(15_000_000_000));
+    target.computeIfAbsent(2, () => item2, BigInt(15_000_000_000));
+
+    expect(target.size).toEqual(2);
+    expect(target.get(1)).toEqual(item1);
+    expect(target.get(2)).toEqual(item2);
+
+    await target.clear();
 
     expect(target.size).toEqual(0);
     expect(target.get(1)).toEqual(undefined);

--- a/tests/unit/writer_failover_handler.test.ts
+++ b/tests/unit/writer_failover_handler.test.ts
@@ -53,7 +53,7 @@ const mockClientWrapper: ClientWrapper = new MySQLClientWrapper(
   mockTargetClient,
   builder.withHost("host").build(),
   new Map<string, any>(),
-  new MySQL2DriverDialect()
+  mockDriverDialect
 );
 
 const mockTargetClientB = { client: 456 };
@@ -61,7 +61,7 @@ const mockClientWrapperB: ClientWrapper = new MySQLClientWrapper(
   mockTargetClientB,
   builder.withHost("host").build(),
   new Map<string, any>(),
-  new MySQL2DriverDialect()
+  mockDriverDialect
 );
 
 describe("writer failover handler", () => {


### PR DESCRIPTION
### Summary

Introduces a new class SlidingExpirationCacheWithCleanupTask that asynchronously cleans up the cache.

### Description

Instead of cleaning up whenever we access the cache, SlidingExpirationCacheWithCleanupTask cleans up all items of the cache that have expired at the rate of cleanupIntervalNanos given in the constructor. 

The cleanup task is only initialized after the first item has been added to the cache. This ensures that static caches can be declared and not used without starting an untracked asynchronous task. 

The clear method is also made asynchronous, when it is called the cleanup task is aborted and all items in the cache are disposed of and cleared. 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
