### PR TITLE
fix: reader failover wait for complete batch

### DIFF
--- a/common/lib/plugins/failover/failover_plugin.ts
+++ b/common/lib/plugins/failover/failover_plugin.ts
@@ -101,6 +101,9 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
     this._properties = properties;
     this.pluginService = pluginService;
     this._rdsHelper = rdsHelper;
+
+    this.initSettings();
+
     this._readerFailoverHandler = readerFailoverHandler
       ? readerFailoverHandler
       : new ClusterAwareReaderFailoverHandler(
@@ -120,7 +123,6 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
           this.failoverClusterTopologyRefreshRateMsSetting,
           this.failoverWriterReconnectIntervalMsSetting
         );
-    this.initSettings();
     this._staleDnsHelper = new StaleDnsHelper(this.pluginService);
 
     const telemetryFactory = this.pluginService.getTelemetryFactory();

--- a/common/lib/utils/locales/en.json
+++ b/common/lib/utils/locales/en.json
@@ -25,6 +25,8 @@
   "ClusterAwareReaderFailoverHandler.attemptingReaderConnection": "Trying to connect to reader: '%s', with properties '%s'",
   "ClusterAwareReaderFailoverHandler.successfulReaderConnection": "Connected to reader: '%s'",
   "ClusterAwareReaderFailoverHandler.failedReaderConnection": "Failed to connect to reader: '%s'",
+  "ClusterAwareReaderFailoverHandler.batchFailed": "Reader connections for hosts [%s] failed with the following errors: %s",
+  "ClusterAwareReaderFailoverHandler.selectedTaskChosen": "Selected task has already been chosen. Abort client for host: %s",
   "Utils.topology": "Topology: %s",
   "RdsHostListProvider.incorrectDialect": "Dialect needs to be a topology aware dialect.",
   "RdsHostListProvider.suggestedClusterId": "ClusterId '%s' is suggested for url '%s'.",

--- a/tests/unit/writer_failover_handler.test.ts
+++ b/tests/unit/writer_failover_handler.test.ts
@@ -28,6 +28,7 @@ import { WriterFailoverResult } from "../../common/lib/plugins/failover/writer_f
 import { ClientWrapper } from "../../common/lib/client_wrapper";
 import { PgDatabaseDialect } from "../../pg/lib/dialect/pg_database_dialect";
 import { MySQLClientWrapper } from "../../common/lib/mysql_client_wrapper";
+import { MySQL2DriverDialect } from "../../mysql/lib/dialect/mysql2_driver_dialect";
 
 const builder = new HostInfoBuilder({ hostAvailabilityStrategy: new SimpleHostAvailabilityStrategy() });
 
@@ -46,10 +47,20 @@ const mockPluginService = mock(PluginService);
 const mockReaderFailover = mock(ClusterAwareReaderFailoverHandler);
 
 const mockTargetClient = { client: 123 };
-const mockClientWrapper: ClientWrapper = new MySQLClientWrapper(mockTargetClient, builder.withHost("host").build(), new Map<string, any>());
+const mockClientWrapper: ClientWrapper = new MySQLClientWrapper(
+  mockTargetClient,
+  builder.withHost("host").build(),
+  new Map<string, any>(),
+  new MySQL2DriverDialect()
+);
 
 const mockTargetClientB = { client: 456 };
-const mockClientWrapperB: ClientWrapper = new MySQLClientWrapper(mockTargetClientB, builder.withHost("host").build(), new Map<string, any>());
+const mockClientWrapperB: ClientWrapper = new MySQLClientWrapper(
+  mockTargetClientB,
+  builder.withHost("host").build(),
+  new Map<string, any>(),
+  new MySQL2DriverDialect()
+);
 
 describe("writer failover handler", () => {
   beforeEach(() => {


### PR DESCRIPTION
### Summary

Fix connections being unclosed in reader failover handler

### Description

- Currently connection attempts are made in batches of two, and the first settled promise is returned. However, if the first connection task fails, the second is also abandoned. This PR changes the reader failover implementation to wait for the entire batch to complete before moving on.
- This PR also changes the failover plugin to initialize the failover settings prior to creating the writer and reader failover handlers.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
