### PR TITLE
fix: error retrieving keep alive settings

### DIFF
--- a/common/lib/profile/driver_configuration_profiles.ts
+++ b/common/lib/profile/driver_configuration_profiles.ts
@@ -27,7 +27,7 @@ import { AwsPoolConfig } from "../aws_pool_config";
 import { StaleDnsPluginFactory } from "../plugins/stale_dns/stale_dns_plugin_factory";
 
 export class DriverConfigurationProfiles {
-  private static readonly MONITORING_CONNECTION_PREFIX = "monitoring-";
+  private static readonly MONITORING_CONNECTION_PREFIX = "monitoring_";
   private static readonly activeProfiles: Map<string, ConfigurationProfile> = new Map<string, ConfigurationProfile>();
   private static readonly presets: Map<string, ConfigurationProfile> = new Map<string, ConfigurationProfile>([
     [

--- a/mysql/lib/dialect/mysql2_driver_dialect.ts
+++ b/mysql/lib/dialect/mysql2_driver_dialect.ts
@@ -76,6 +76,10 @@ export class MySQL2DriverDialect implements DriverDialect {
   }
 
   setKeepAliveProperties(props: Map<string, any>, keepAliveProps: any) {
+    if (keepAliveProps instanceof Map) {
+      keepAliveProps = Object.fromEntries(keepAliveProps);
+    }
+
     if (keepAliveProps && keepAliveProps[MySQL2DriverDialect.KEEP_ALIVE_PROPERTY_NAME] !== undefined) {
       throw new UnsupportedMethodError("Keep alive configuration is not supported for MySQL2.");
     }

--- a/mysql/lib/dialect/mysql2_driver_dialect.ts
+++ b/mysql/lib/dialect/mysql2_driver_dialect.ts
@@ -76,7 +76,7 @@ export class MySQL2DriverDialect implements DriverDialect {
   }
 
   setKeepAliveProperties(props: Map<string, any>, keepAliveProps: any) {
-    if (keepAliveProps && keepAliveProps.get(MySQL2DriverDialect.KEEP_ALIVE_PROPERTY_NAME)) {
+    if (keepAliveProps && keepAliveProps[MySQL2DriverDialect.KEEP_ALIVE_PROPERTY_NAME] !== undefined) {
       throw new UnsupportedMethodError("Keep alive configuration is not supported for MySQL2.");
     }
   }

--- a/pg/lib/dialect/node_postgres_driver_dialect.ts
+++ b/pg/lib/dialect/node_postgres_driver_dialect.ts
@@ -41,7 +41,7 @@ export class NodePostgresDriverDialect implements DriverDialect {
     const driverProperties = WrapperProperties.removeWrapperProperties(props);
     this.setKeepAliveProperties(driverProperties, props.get(WrapperProperties.KEEPALIVE_PROPERTIES.name));
     this.setConnectTimeout(driverProperties, props.get(WrapperProperties.WRAPPER_CONNECT_TIMEOUT.name));
-    this.setQueryTimeout(driverProperties, props.get(WrapperProperties.WRAPPER_QUERY_TIMEOUT.name));
+    this.setQueryTimeout(driverProperties, undefined, props.get(WrapperProperties.WRAPPER_QUERY_TIMEOUT.name));
     const targetClient = new pkgPg.Client(Object.fromEntries(driverProperties.entries()));
     await targetClient.connect();
     return Promise.resolve(new PgClientWrapper(targetClient, hostInfo, props));

--- a/pg/lib/dialect/node_postgres_driver_dialect.ts
+++ b/pg/lib/dialect/node_postgres_driver_dialect.ts
@@ -83,6 +83,10 @@ export class NodePostgresDriverDialect implements DriverDialect {
       return;
     }
 
+    if (keepAliveProps instanceof Map) {
+      keepAliveProps = Object.fromEntries(keepAliveProps);
+    }
+
     const keepAlive = keepAliveProps[NodePostgresDriverDialect.KEEP_ALIVE_PROPERTY_NAME];
     const keepAliveInitialDelayMillis = keepAliveProps[NodePostgresDriverDialect.KEEP_ALIVE_INITIAL_DELAY_MILLIS_PROPERTY_NAME];
 

--- a/pg/lib/dialect/node_postgres_driver_dialect.ts
+++ b/pg/lib/dialect/node_postgres_driver_dialect.ts
@@ -83,13 +83,13 @@ export class NodePostgresDriverDialect implements DriverDialect {
       return;
     }
 
-    const keepAlive = keepAliveProps.get(NodePostgresDriverDialect.KEEP_ALIVE_PROPERTY_NAME);
-    const keepAliveInitialDelayMillis = keepAliveProps.get(NodePostgresDriverDialect.KEEP_ALIVE_INITIAL_DELAY_MILLIS_PROPERTY_NAME);
+    const keepAlive = keepAliveProps[NodePostgresDriverDialect.KEEP_ALIVE_PROPERTY_NAME];
+    const keepAliveInitialDelayMillis = keepAliveProps[NodePostgresDriverDialect.KEEP_ALIVE_INITIAL_DELAY_MILLIS_PROPERTY_NAME];
 
-    if (keepAlive) {
+    if (keepAlive !== undefined) {
       props.set(NodePostgresDriverDialect.KEEP_ALIVE_PROPERTY_NAME, keepAlive);
     }
-    if (keepAliveInitialDelayMillis) {
+    if (keepAliveInitialDelayMillis !== undefined) {
       props.set(NodePostgresDriverDialect.KEEP_ALIVE_INITIAL_DELAY_MILLIS_PROPERTY_NAME, keepAliveInitialDelayMillis);
     }
   }

--- a/tests/unit/aurora_connection_tracker.test.ts
+++ b/tests/unit/aurora_connection_tracker.test.ts
@@ -29,6 +29,8 @@ import { ClientWrapper } from "../../common/lib/client_wrapper";
 import { HostInfo } from "../../common/lib/host_info";
 import { MySQLClientWrapper } from "../../common/lib/mysql_client_wrapper";
 import { jest } from "@jest/globals";
+import { DriverDialect } from "../../common/lib/driver_dialect/driver_dialect";
+import { MySQL2DriverDialect } from "../../mysql/lib/dialect/mysql2_driver_dialect";
 
 const props = new Map<string, any>();
 const SQL_ARGS = ["sql"];
@@ -48,8 +50,9 @@ const mockRdsUtils = mock(RdsUtils);
 const mockClient = mock(AwsClient);
 const mockHostInfo = mock(HostInfo);
 
+const mockDriverDialect: DriverDialect = mock(MySQL2DriverDialect);
 const mockClientInstance = instance(mockClient);
-const mockClientWrapper: ClientWrapper = new MySQLClientWrapper(undefined, mockHostInfo, props);
+const mockClientWrapper: ClientWrapper = new MySQLClientWrapper(undefined, mockHostInfo, props, mockDriverDialect);
 
 mockClientInstance.targetClient = mockClientWrapper;
 

--- a/tests/unit/aurora_initial_connection_strategy_plugin.test.ts
+++ b/tests/unit/aurora_initial_connection_strategy_plugin.test.ts
@@ -30,6 +30,8 @@ import { AwsWrapperError } from "../../common/lib/utils/errors";
 import { MySQLClientWrapper } from "../../common/lib/mysql_client_wrapper";
 import { jest } from "@jest/globals";
 import { PgClientWrapper } from "../../common/lib/pg_client_wrapper";
+import { DriverDialect } from "../../common/lib/driver_dialect/driver_dialect";
+import { MySQL2DriverDialect } from "../../mysql/lib/dialect/mysql2_driver_dialect";
 
 const mockPluginService = mock(PluginService);
 const mockHostListProviderService = mock<HostListProviderService>();
@@ -48,6 +50,7 @@ const hostInfo = hostInfoBuilder.withHost("host").build();
 
 const writerHostInfo = hostInfoBuilder.withHost("host").withRole(HostRole.WRITER).build();
 const readerHostInfo = hostInfoBuilder.withHost("host").withHost(HostRole.READER).build();
+const mockDriverDialect: DriverDialect = mock(MySQL2DriverDialect);
 
 describe("Aurora initial connection strategy plugin", () => {
   let props: Map<string, any>;
@@ -62,8 +65,8 @@ describe("Aurora initial connection strategy plugin", () => {
     plugin.initHostProvider(hostInfo, props, instance(mockHostListProviderService), mockFunc);
     WrapperProperties.OPEN_CONNECTION_RETRY_TIMEOUT_MS.set(props, 1000);
 
-    writerClient = new MySQLClientWrapper(undefined, writerHostInfo, new Map<string, any>());
-    readerClient = new MySQLClientWrapper(undefined, readerHostInfo, new Map<string, any>());
+    writerClient = new MySQLClientWrapper(undefined, writerHostInfo, new Map<string, any>(), mockDriverDialect);
+    readerClient = new MySQLClientWrapper(undefined, readerHostInfo, new Map<string, any>(), mockDriverDialect);
   });
 
   afterEach(() => {

--- a/tests/unit/database_dialect.test.ts
+++ b/tests/unit/database_dialect.test.ts
@@ -278,8 +278,7 @@ describe("test database dialects", () => {
       databaseType,
       expectedDialect!.dialects,
       props,
-      mockDriverDialect,
-      null
+      mockDriverDialect
     );
     await pluginService.updateDialect(mockClientWrapper);
     expect(pluginService.getDialect()).toBe(expectedDialectClass);

--- a/tests/unit/driver_dialect.test.ts
+++ b/tests/unit/driver_dialect.test.ts
@@ -1,0 +1,73 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { mock } from "ts-mockito";
+import { MySQL2DriverDialect } from "../../mysql/lib/dialect/mysql2_driver_dialect";
+import { HostInfo } from "../../common/lib/host_info";
+import { UnsupportedMethodError } from "../../common/lib/utils/errors";
+import { NodePostgresDriverDialect } from "../../pg/lib/dialect/node_postgres_driver_dialect";
+
+const mockHostInfo: HostInfo = mock(HostInfo);
+const emptyProps: Map<string, any> = new Map<string, any>();
+
+describe("driverDialectTest", () => {
+  it("test_connectWithKeepAliveProps_MySQL_shouldThrow", async () => {
+    const keepAliveProps = new Map<string, any>([
+      ["keepAlive", true],
+      ["keepAliveInitialDelayMillis", 1234]
+    ]);
+
+    const props = new Map<string, any>([["wrapperKeepAliveProperties", keepAliveProps]]);
+
+    const dialect = new MySQL2DriverDialect();
+    const unsupportedError = new UnsupportedMethodError("Keep alive configuration is not supported for MySQL2.");
+
+    await expect(dialect.connect(mockHostInfo, props)).rejects.toThrow(unsupportedError);
+
+    const keepAliveObj = {
+      keepAlive: true,
+      keepAliveInitialDelayMillis: 1234
+    };
+
+    const propsWithObj = new Map<string, any>([["wrapperKeepAliveProperties", keepAliveObj]]);
+
+    await expect(dialect.connect(mockHostInfo, propsWithObj)).rejects.toThrow(unsupportedError);
+  });
+
+  it("test_connectWithKeepAliveProps_PG_shouldSucceed", async () => {
+    const keepAliveMap = new Map<string, any>([
+      ["keepAlive", true],
+      ["keepAliveInitialDelayMillis", 1234]
+    ]);
+
+    const dialect = new NodePostgresDriverDialect();
+
+    dialect.setKeepAliveProperties(emptyProps, keepAliveMap);
+    expect(emptyProps.get("keepAlive")).toBe(true);
+    expect(emptyProps.get("keepAliveInitialDelayMillis")).toBe(1234);
+
+    emptyProps.clear();
+
+    const keepAliveObj = {
+      keepAlive: true,
+      keepAliveInitialDelayMillis: 1234
+    };
+
+    dialect.setKeepAliveProperties(emptyProps, keepAliveObj);
+    expect(emptyProps.get("keepAlive")).toBe(true);
+    expect(emptyProps.get("keepAliveInitialDelayMillis")).toBe(1234);
+  });
+});

--- a/tests/unit/failover_plugin.test.ts
+++ b/tests/unit/failover_plugin.test.ts
@@ -38,6 +38,8 @@ import { Messages } from "../../common/lib/utils/messages";
 import { HostChangeOptions } from "../../common/lib/host_change_options";
 import { NullTelemetryFactory } from "../../common/lib/utils/telemetry/null_telemetry_factory";
 import { MySQLClientWrapper } from "../../common/lib/mysql_client_wrapper";
+import { DriverDialect } from "../../common/lib/driver_dialect/driver_dialect";
+import { MySQL2DriverDialect } from "../../mysql/lib/dialect/mysql2_driver_dialect";
 
 const builder = new HostInfoBuilder({ hostAvailabilityStrategy: new SimpleHostAvailabilityStrategy() });
 
@@ -52,8 +54,9 @@ let mockWriterFailoverHandlerInstance;
 const mockWriterFailoverHandler: ClusterAwareWriterFailoverHandler = mock(ClusterAwareWriterFailoverHandler);
 const mockReaderResult: ReaderFailoverResult = mock(ReaderFailoverResult);
 const mockWriterResult: WriterFailoverResult = mock(WriterFailoverResult);
+const mockDriverDialect: DriverDialect = mock(MySQL2DriverDialect);
 
-const mockClientWrapper = new MySQLClientWrapper(undefined, mockHostInfo, new Map<string, any>());
+const mockClientWrapper = new MySQLClientWrapper(undefined, mockHostInfo, new Map<string, any>(), mockDriverDialect);
 
 const properties: Map<string, any> = new Map();
 

--- a/tests/unit/writer_failover_handler.test.ts
+++ b/tests/unit/writer_failover_handler.test.ts
@@ -28,6 +28,7 @@ import { WriterFailoverResult } from "../../common/lib/plugins/failover/writer_f
 import { ClientWrapper } from "../../common/lib/client_wrapper";
 import { PgDatabaseDialect } from "../../pg/lib/dialect/pg_database_dialect";
 import { MySQLClientWrapper } from "../../common/lib/mysql_client_wrapper";
+import { DriverDialect } from "../../common/lib/driver_dialect/driver_dialect";
 import { MySQL2DriverDialect } from "../../mysql/lib/dialect/mysql2_driver_dialect";
 
 const builder = new HostInfoBuilder({ hostAvailabilityStrategy: new SimpleHostAvailabilityStrategy() });
@@ -45,6 +46,7 @@ const mockClient = mock(AwsPGClient); // Using AwsPGClient in order to have abst
 const mockClientInstance = instance(mockClient);
 const mockPluginService = mock(PluginService);
 const mockReaderFailover = mock(ClusterAwareReaderFailoverHandler);
+const mockDriverDialect: DriverDialect = mock(MySQL2DriverDialect);
 
 const mockTargetClient = { client: 123 };
 const mockClientWrapper: ClientWrapper = new MySQLClientWrapper(


### PR DESCRIPTION
### Summary

Calling `keepAliveProps.get(...)` will throw errors instead of returning undefined because `keepAliveProps` is not a map object.

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
