### PR TITLE
feat: multi-az failover2

### DIFF
--- a/common/lib/host_list_provider/host_list_provider.ts
+++ b/common/lib/host_list_provider/host_list_provider.ts
@@ -25,6 +25,8 @@ export type StaticHostListProvider = HostListProvider;
 
 export interface BlockingHostListProvider extends HostListProvider {
   forceMonitoringRefresh(shouldVerifyWriter: boolean, timeoutMs: number): Promise<HostInfo[]>;
+
+  clearAll(): Promise<void>;
 }
 
 export interface HostListProvider {

--- a/common/lib/plugin_service.ts
+++ b/common/lib/plugin_service.ts
@@ -198,7 +198,7 @@ export class PluginService implements ErrorHandler, HostListProviderService {
     return false;
   }
 
-  protected isBlockingHostListProvider(arg: any): arg is BlockingHostListProvider {
+  isBlockingHostListProvider(arg: any): arg is BlockingHostListProvider {
     return arg;
   }
 

--- a/common/lib/topology_aware_database_dialect.ts
+++ b/common/lib/topology_aware_database_dialect.ts
@@ -26,5 +26,6 @@ export interface TopologyAwareDatabaseDialect {
 
   getHostRole(client: ClientWrapper): Promise<HostRole>;
 
-  getWriterId(client: ClientWrapper): Promise<string | null>;
+  // Returns the host id of the targetClient if it is connected to a writer, null otherwise.
+  getWriterId(targetClient: ClientWrapper): Promise<string | null>;
 }

--- a/mysql/lib/dialect/rds_multi_az_mysql_database_dialect.ts
+++ b/mysql/lib/dialect/rds_multi_az_mysql_database_dialect.ts
@@ -137,9 +137,9 @@ export class RdsMultiAZMySQLDatabaseDialect extends MySQLDatabaseDialect impleme
         RdsMultiAZMySQLDatabaseDialect.FETCH_WRITER_HOST_QUERY_COLUMN_NAME
       );
       // The above query returns the writer host id if it is a reader, nothing if the writer.
-      if ((!writerHostId)) {
+      if (!writerHostId) {
         const currentConnection = await this.identifyConnection(targetClient);
-        return currentConnection ? currentConnection : null;
+        return currentConnection ?? null;
       } else {
         return null;
       }

--- a/pg/lib/dialect/rds_multi_az_pg_database_dialect.ts
+++ b/pg/lib/dialect/rds_multi_az_pg_database_dialect.ts
@@ -143,11 +143,7 @@ export class RdsMultiAZPgDatabaseDialect extends PgDatabaseDialect implements To
       );
       const currentConnection = await this.identifyConnection(targetClient);
 
-      if (currentConnection === writerHostId) {
-        return currentConnection ? currentConnection : null;
-      } else {
-        return null;
-      }
+      return (currentConnection && currentConnection === writerHostId) ? currentConnection : null;
     } catch (error: any) {
       throw new AwsWrapperError(Messages.get("RdsMultiAZPgDatabaseDialect.invalidQuery", error.message));
     }

--- a/pg/lib/dialect/rds_multi_az_pg_database_dialect.ts
+++ b/pg/lib/dialect/rds_multi_az_pg_database_dialect.ts
@@ -27,7 +27,9 @@ import { RdsHostListProvider } from "../../../common/lib/host_list_provider/rds_
 import { PgDatabaseDialect } from "./pg_database_dialect";
 import { ErrorHandler } from "../../../common/lib/error_handler";
 import { MultiAzPgErrorHandler } from "../multi_az_pg_error_handler";
-import { error, info, query } from "winston";
+import { WrapperProperties } from "../../../common/lib/wrapper_property";
+import { PluginService } from "../../../common/lib/plugin_service";
+import { MonitoringRdsHostListProvider } from "../../../common/lib/host_list_provider/monitoring/monitoring_host_list_provider";
 
 export class RdsMultiAZPgDatabaseDialect extends PgDatabaseDialect implements TopologyAwareDatabaseDialect {
   constructor() {
@@ -42,7 +44,8 @@ export class RdsMultiAZPgDatabaseDialect extends PgDatabaseDialect implements To
   private static readonly FETCH_WRITER_HOST_QUERY_COLUMN_NAME: string = "multi_az_db_cluster_source_dbi_resource_id";
   private static readonly HOST_ID_QUERY: string = "SELECT dbi_resource_id FROM rds_tools.dbi_resource_id()";
   private static readonly HOST_ID_QUERY_COLUMN_NAME: string = "dbi_resource_id";
-  private static readonly IS_READER_QUERY: string = "SELECT pg_is_in_recovery()";
+  private static readonly IS_READER_QUERY: string = "SELECT pg_is_in_recovery() AS is_reader";
+  private static readonly IS_READER_QUERY_COLUMN_NAME: string = "is_reader";
 
   async isDialect(targetClient: ClientWrapper): Promise<boolean> {
     const res = await targetClient.query(RdsMultiAZPgDatabaseDialect.WRITER_HOST_FUNC_EXIST_QUERY).catch(() => false);
@@ -55,6 +58,9 @@ export class RdsMultiAZPgDatabaseDialect extends PgDatabaseDialect implements To
   }
 
   getHostListProvider(props: Map<string, any>, originalUrl: string, hostListProviderService: HostListProviderService): HostListProvider {
+    if (WrapperProperties.PLUGINS.get(props).includes("failover2")) {
+      return new MonitoringRdsHostListProvider(props, originalUrl, hostListProviderService, <PluginService>hostListProviderService);
+    }
     return new RdsHostListProvider(props, originalUrl, hostListProviderService);
   }
 
@@ -77,7 +83,7 @@ export class RdsMultiAZPgDatabaseDialect extends PgDatabaseDialect implements To
     }
   }
 
-  private async executeTopologyRelatedQuery(targetClient: ClientWrapper, query: string, resultColumnName?: string): Promise<string> {
+  private async executeTopologyRelatedQuery(targetClient: ClientWrapper, query: string, resultColumnName?: string): Promise<any> {
     const res = await targetClient.query(query);
     const rows: any[] = res.rows;
     if (rows.length > 0) {
@@ -125,11 +131,26 @@ export class RdsMultiAZPgDatabaseDialect extends PgDatabaseDialect implements To
   }
 
   async getHostRole(client: ClientWrapper): Promise<HostRole> {
-    return (await this.executeTopologyRelatedQuery(client, RdsMultiAZPgDatabaseDialect.IS_READER_QUERY)) ? HostRole.WRITER : HostRole.READER;
+    return (await this.executeTopologyRelatedQuery(client, RdsMultiAZPgDatabaseDialect.IS_READER_QUERY, RdsMultiAZPgDatabaseDialect.IS_READER_QUERY_COLUMN_NAME)) === false ? HostRole.WRITER : HostRole.READER;
   }
 
-  getWriterId(client: ClientWrapper): Promise<string> {
-    throw new Error("Method not implemented.");
+  async getWriterId(targetClient: ClientWrapper): Promise<string> {
+    try {
+      const writerHostId: string = await this.executeTopologyRelatedQuery(
+        targetClient,
+        RdsMultiAZPgDatabaseDialect.FETCH_WRITER_HOST_QUERY,
+        RdsMultiAZPgDatabaseDialect.FETCH_WRITER_HOST_QUERY_COLUMN_NAME
+      );
+      const currentConnection = await this.identifyConnection(targetClient);
+
+      if (currentConnection === writerHostId) {
+        return currentConnection ? currentConnection : null;
+      } else {
+        return null;
+      }
+    } catch (error: any) {
+      throw new AwsWrapperError(Messages.get("RdsMultiAZPgDatabaseDialect.invalidQuery", error.message));
+    }
   }
 
   getErrorHandler(): ErrorHandler {


### PR DESCRIPTION
### Summary

Adds handling for multi-az clusters to failover2.

### Description

- Implements the getWriterId method in the multi-az dialects 
- Fixes getHostRole to correctly return when connected to a writer. 
- Consolidates all read write splitting tests into one file.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
