### PR TITLE
chore: refactor FailoverErrors

### DIFF
--- a/common/lib/plugins/failover/failover_plugin.ts
+++ b/common/lib/plugins/failover/failover_plugin.ts
@@ -352,7 +352,7 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
 
           if (!result || !result.isConnected || !result.newHost || !result.client) {
             // "Unable to establish SQL connection to reader instance"
-            throw new FailoverFailedError(Messages.get("Failover.unableToConnectToReader"));
+            throw new FailoverFailedError();
           }
 
           await this.pluginService.abortCurrentClient();
@@ -383,7 +383,7 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
     } else {
       // "The active SQL connection has changed due to a connection failure. Please re-configure
       // session state if required."
-      throw new FailoverSuccessError(Messages.get("Failover.connectionChangedError"));
+      throw new FailoverSuccessError();
     }
   }
 
@@ -408,7 +408,7 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
 
           if (!result || !result.isConnected || !result.client) {
             // "Unable to establish SQL connection to writer host"
-            throw new FailoverFailedError(Messages.get("Failover.unableToConnectToWriter"));
+            throw new FailoverFailedError();
           }
 
           // successfully re-connected to a writer host
@@ -427,7 +427,7 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
             );
             logger.error(failoverErrorMessage);
             await this.pluginService.abortTargetClient(result.client);
-            throw new FailoverFailedError(failoverErrorMessage);
+            throw new FailoverFailedError();
           }
 
           await this.pluginService.abortCurrentClient();

--- a/common/lib/plugins/failover2/failover2_plugin.ts
+++ b/common/lib/plugins/failover2/failover2_plugin.ts
@@ -242,7 +242,7 @@ export class Failover2Plugin extends AbstractConnectionPlugin implements CanRele
     } else {
       // "The active SQL connection has changed due to a connection failure. Please re-configure
       // session state if required."
-      throw new FailoverSuccessError(Messages.get("Failover.connectionChangedError"));
+      throw new FailoverSuccessError();
     }
   }
 
@@ -261,7 +261,7 @@ export class Failover2Plugin extends AbstractConnectionPlugin implements CanRele
           // Unable to establish SQL connection to an instance.
           this.failoverReaderFailedCounter.inc();
           logger.error(Messages.get("Failover2.unableToFetchTopology"));
-          throw new FailoverFailedError(Messages.get("Failover2.unableToFetchTopology"));
+          throw new FailoverFailedError();
         }
         try {
           const result: ReaderFailoverResult = await this.getReaderFailoverConnection(failoverEndTimeMs);
@@ -274,7 +274,7 @@ export class Failover2Plugin extends AbstractConnectionPlugin implements CanRele
         } catch (error) {
           this.failoverReaderFailedCounter.inc();
           logger.error(Messages.get("Failover.unableToConnectToReader"));
-          throw new FailoverFailedError(Messages.get("Failover.unableToConnectToReader"));
+          throw new FailoverFailedError();
         }
       });
     } finally {
@@ -396,7 +396,7 @@ export class Failover2Plugin extends AbstractConnectionPlugin implements CanRele
             logTopology(allowedHosts, "[Failover.newWriterNotAllowed] ")
           );
           logger.error(failoverErrorMessage);
-          throw new FailoverFailedError(failoverErrorMessage);
+          throw new FailoverFailedError();
         }
 
         if (writerCandidateHostInfo) {
@@ -489,12 +489,12 @@ export class Failover2Plugin extends AbstractConnectionPlugin implements CanRele
   private logAndThrowError(errorMessage: string) {
     logger.error(errorMessage);
     this.failoverWriterFailedCounter.inc();
-    throw new FailoverFailedError(errorMessage);
+    throw new FailoverFailedError();
   }
 
   async releaseResources(): Promise<void> {
     const hostListProvider: HostListProvider = this.pluginService.getHostListProvider();
-    if (!!this.pluginService.isBlockingHostListProvider(hostListProvider)) {
+    if (this.pluginService.isBlockingHostListProvider(hostListProvider)) {
       await hostListProvider.clearAll();
     }
   }

--- a/tests/unit/failover2_plugin.test.ts
+++ b/tests/unit/failover2_plugin.test.ts
@@ -96,7 +96,7 @@ describe("reader failover handler", () => {
     when(spyPlugin.failoverReader()).thenResolve();
     plugin.failoverMode = FailoverMode.READER_OR_WRITER;
 
-    await expect(plugin.failover()).rejects.toThrow(new FailoverSuccessError(Messages.get("Failover.connectionChangedError")));
+    await expect(plugin.failover()).rejects.toThrow(new FailoverSuccessError());
 
     verify(spyPlugin.failoverReader()).once();
   });

--- a/tests/unit/failover_plugin.test.ts
+++ b/tests/unit/failover_plugin.test.ts
@@ -187,7 +187,7 @@ describe("reader failover handler", () => {
     when(spyPlugin.failoverReader(mockHostInfoInstance)).thenResolve();
     plugin.failoverMode = FailoverMode.READER_OR_WRITER;
 
-    await expect(plugin.failover(mockHostInfoInstance)).rejects.toThrow(new FailoverSuccessError(Messages.get("Failover.connectionChangedError")));
+    await expect(plugin.failover(mockHostInfoInstance)).rejects.toThrow(new FailoverSuccessError());
 
     verify(spyPlugin.failoverReader(mockHostInfoInstance)).once();
   });


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

Some errors such as: FailoverSuccessError FailoverFailedError will always have the same error message.
Refactor these errors so we don't have to pass the same error message to every call.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
