### PR TITLE
fix: round robin strategy initial host list is cluster endpoint

### DIFF
--- a/common/lib/plugins/aurora_initial_connection_strategy_plugin.ts
+++ b/common/lib/plugins/aurora_initial_connection_strategy_plugin.ts
@@ -191,16 +191,13 @@ export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
       readerCandidate = null;
 
       try {
+        readerCandidateClient = await connectFunc();
+        await this.pluginService.forceRefreshHostList(readerCandidateClient);
+        readerCandidate = await this.pluginService.identifyConnection(readerCandidateClient);
         readerCandidate = this.getReader(props);
         // convert into null if undefined
         readerCandidate = readerCandidate ?? null;
-
         if (readerCandidate === null || this.rdsUtils.isRdsClusterDns(readerCandidate.host)) {
-          // Reader is not found. It seems that topology is outdated.
-          readerCandidateClient = await connectFunc();
-          await this.pluginService.forceRefreshHostList(readerCandidateClient);
-          readerCandidate = await this.pluginService.identifyConnection(readerCandidateClient);
-
           if (readerCandidate) {
             if (readerCandidate.role !== HostRole.READER) {
               if (this.hasNoReaders()) {
@@ -223,7 +220,6 @@ export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
           } else {
             logger.debug("Reader candidate not found");
           }
-          return readerCandidateClient;
         }
         readerCandidateClient = await this.pluginService.connect(readerCandidate, props);
 

--- a/common/lib/plugins/aurora_initial_connection_strategy_plugin.ts
+++ b/common/lib/plugins/aurora_initial_connection_strategy_plugin.ts
@@ -191,13 +191,18 @@ export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
       readerCandidate = null;
 
       try {
-        readerCandidateClient = await connectFunc();
-        await this.pluginService.forceRefreshHostList(readerCandidateClient);
-        readerCandidate = await this.pluginService.identifyConnection(readerCandidateClient);
         readerCandidate = this.getReader(props);
         // convert into null if undefined
         readerCandidate = readerCandidate ?? null;
+
         if (readerCandidate === null || this.rdsUtils.isRdsClusterDns(readerCandidate.host)) {
+          // Reader is not found. It seems that topology is outdated.
+          readerCandidateClient = await connectFunc();
+          await this.pluginService.forceRefreshHostList(readerCandidateClient);
+          readerCandidate = await this.pluginService.identifyConnection(readerCandidateClient);
+          if (isInitialConnection) {
+            readerCandidate = this.getReader(props);
+          }
           if (readerCandidate) {
             if (readerCandidate.role !== HostRole.READER) {
               if (this.hasNoReaders()) {
@@ -220,6 +225,7 @@ export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
           } else {
             logger.debug("Reader candidate not found");
           }
+          return readerCandidateClient;
         }
         readerCandidateClient = await this.pluginService.connect(readerCandidate, props);
 


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

In the InitialConnectionStrategyPlugin, in getVerifiedReaderClient when getReader is called, this causes us to get our host with the roundRobin strategy via the getHost method.

 On the first connection, we are passing in the cluster endpoint into hosts ` getHost(hosts: HostInfo[], role: HostRole, props?: Map<string, any>)`. It is not until we call ` const readerCandidate = await this.pluginService.identifyConnection(readerCandidateClient);` that we actually know the list of hosts. 

So when roundRobin Host Selector looks for the list for eligibleHosts upon the initial connection, it receives the cluster endpoint.

By moving the call to getReader after the readerCandidate is retrieved, `getHost(hosts: HostInfo[], role: HostRole, props?: Map<string, any>) ` now passes in the host list which contains the list of eligible instances 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
