### PR TITLE
fix: plugin chain cache cannot retrieve chain

### DIFF
--- a/common/lib/plugin_manager.ts
+++ b/common/lib/plugin_manager.ts
@@ -63,7 +63,7 @@ class PluginChain<T> {
 }
 
 export class PluginManager {
-  private static readonly PLUGIN_CHAIN_CACHE = new Map<[string, HostInfo], PluginChain<any>>();
+  private static readonly PLUGIN_CHAIN_CACHE = new Map<string, PluginChain<any>>();
   private static readonly STRATEGY_PLUGIN_CHAIN_CACHE = new Map<ConnectionPlugin[], Set<ConnectionPlugin>>();
   private static readonly ALL_METHODS: string = "*";
   private static readonly CONNECT_METHOD = "connect";
@@ -189,10 +189,10 @@ export class PluginManager {
     pluginFunc: PluginFunc<T>,
     methodFunc: () => Promise<T>
   ): Promise<T> {
-    let chain = PluginManager.PLUGIN_CHAIN_CACHE.get([methodName, hostInfo]);
+    let chain = PluginManager.PLUGIN_CHAIN_CACHE.get(JSON.stringify([methodName, hostInfo.host]));
     if (!chain) {
       chain = this.makeExecutePipeline(hostInfo, props, methodName, methodFunc);
-      PluginManager.PLUGIN_CHAIN_CACHE.set([methodName, hostInfo], chain);
+      PluginManager.PLUGIN_CHAIN_CACHE.set(JSON.stringify([methodName, hostInfo.host]), chain);
     }
     return chain.execute(pluginFunc);
   }


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

Attempting to retrieve a plugin chain from the plugin chain cache will not succeed; new plugin chains are always created. We want to use arrays as keys based on their contents instead
### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
