### PR TITLE
refactor: improve force connect pipeline

### DIFF
--- a/common/lib/plugin_service.ts
+++ b/common/lib/plugin_service.ts
@@ -44,6 +44,7 @@ import { getWriter, logTopology } from "./utils/utils";
 import { TelemetryFactory } from "./utils/telemetry/telemetry_factory";
 import { DriverDialect } from "./driver_dialect/driver_dialect";
 import { AllowedAndBlockedHosts } from "./AllowedAndBlockedHosts";
+import { ConnectionPlugin } from "./connection_plugin";
 
 export interface PluginService extends ErrorHandler {
   isInTransaction(): boolean;
@@ -108,7 +109,15 @@ export interface PluginService extends ErrorHandler {
 
   connect(hostInfo: HostInfo, props: Map<string, any>): Promise<ClientWrapper>;
 
+  connect(hostInfo: HostInfo, props: Map<string, any>, pluginToSkip: ConnectionPlugin | null): Promise<ClientWrapper>;
+
+  connect(hostInfo: HostInfo, props: Map<string, any>, pluginToSkip?: ConnectionPlugin | null): Promise<ClientWrapper>;
+
   forceConnect(hostInfo: HostInfo, props: Map<string, any>): Promise<ClientWrapper>;
+
+  forceConnect(hostInfo: HostInfo, props: Map<string, any>, pluginToSkip: ConnectionPlugin | null): Promise<ClientWrapper>;
+
+  forceConnect(hostInfo: HostInfo, props: Map<string, any>, pluginToSkip?: ConnectionPlugin | null): Promise<ClientWrapper>;
 
   setCurrentClient(newClient: ClientWrapper, hostInfo: HostInfo): Promise<Set<HostChangeOptions>>;
 
@@ -495,12 +504,16 @@ export class PluginServiceImpl implements PluginService, HostListProviderService
     return provider.identifyConnection(targetClient, this.dialect);
   }
 
-  connect(hostInfo: HostInfo, props: Map<string, any>): Promise<ClientWrapper> {
-    return this.pluginServiceManagerContainer.pluginManager!.connect(hostInfo, props, false);
+  connect(hostInfo: HostInfo, props: Map<string, any>): Promise<ClientWrapper>;
+  connect(hostInfo: HostInfo, props: Map<string, any>, pluginToSkip: ConnectionPlugin): Promise<ClientWrapper>;
+  connect(hostInfo: HostInfo, props: Map<string, any>, pluginToSkip?: ConnectionPlugin): Promise<ClientWrapper> {
+    return this.pluginServiceManagerContainer.pluginManager!.connect(hostInfo, props, false, pluginToSkip);
   }
 
-  forceConnect(hostInfo: HostInfo, props: Map<string, any>): Promise<ClientWrapper> {
-    return this.pluginServiceManagerContainer.pluginManager!.forceConnect(hostInfo, props, false);
+  forceConnect(hostInfo: HostInfo, props: Map<string, any>): Promise<ClientWrapper>;
+  forceConnect(hostInfo: HostInfo, props: Map<string, any>, pluginToSkip: ConnectionPlugin): Promise<ClientWrapper>;
+  forceConnect(hostInfo: HostInfo, props: Map<string, any>, pluginToSkip?: ConnectionPlugin): Promise<ClientWrapper> {
+    return this.pluginServiceManagerContainer.pluginManager!.forceConnect(hostInfo, props, false, pluginToSkip);
   }
 
   async setCurrentClient(newClient: ClientWrapper, hostInfo: HostInfo): Promise<Set<HostChangeOptions>> {

--- a/common/lib/plugins/aurora_initial_connection_strategy_plugin.ts
+++ b/common/lib/plugins/aurora_initial_connection_strategy_plugin.ts
@@ -30,7 +30,7 @@ import { logger } from "../../logutils";
 import { ClientWrapper } from "../client_wrapper";
 
 export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlugin {
-  private static readonly subscribedMethods = new Set<string>(["initHostProvider", "connect", "forceConnect"]);
+  private static readonly subscribedMethods = new Set<string>(["initHostProvider", "connect"]);
   private pluginService: PluginService;
   private hostListProviderService?: HostListProviderService;
   private rdsUtils = new RdsUtils();
@@ -58,24 +58,6 @@ export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
   }
 
   async connect(
-    hostInfo: HostInfo,
-    props: Map<string, any>,
-    isInitialConnection: boolean,
-    connectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    return this.connectInternal(hostInfo, props, isInitialConnection, connectFunc);
-  }
-
-  async forceConnect(
-    hostInfo: HostInfo,
-    props: Map<string, any>,
-    isInitialConnection: boolean,
-    forceConnectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    return this.connectInternal(hostInfo, props, isInitialConnection, forceConnectFunc);
-  }
-
-  async connectInternal(
     hostInfo: HostInfo,
     props: Map<string, any>,
     isInitialConnection: boolean,
@@ -148,7 +130,7 @@ export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
           }
           return writerCandidateClient;
         }
-        writerCandidateClient = await this.pluginService.connect(writerCandidate, props);
+        writerCandidateClient = await this.pluginService.connect(writerCandidate, props, this);
 
         if ((await this.pluginService.getHostRole(writerCandidateClient)) !== HostRole.WRITER) {
           // If the new connection resolves to a reader instance, this means the topology is outdated.
@@ -225,7 +207,7 @@ export class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
           }
           return readerCandidateClient;
         }
-        readerCandidateClient = await this.pluginService.connect(readerCandidate, props);
+        readerCandidateClient = await this.pluginService.connect(readerCandidate, props, this);
 
         if ((await this.pluginService.getHostRole(readerCandidateClient)) !== HostRole.READER) {
           // If the new connection resolves to a writer instance, this means the topology is outdated.

--- a/common/lib/plugins/connection_tracker/aurora_connection_tracker_plugin.ts
+++ b/common/lib/plugins/connection_tracker/aurora_connection_tracker_plugin.ts
@@ -28,7 +28,7 @@ import { HostRole } from "../../host_role";
 import { OpenedConnectionTracker } from "./opened_connection_tracker";
 
 export class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin implements CanReleaseResources {
-  private static readonly subscribedMethods = new Set<string>(["notifyHostListChanged"].concat(SubscribedMethodHelper.NETWORK_BOUND_METHODS));
+  private static readonly subscribedMethods = new Set<string>(["notifyHostListChanged", "connect", "query", "rollback"]);
 
   private readonly pluginService: PluginService;
   private readonly rdsUtils: RdsUtils;
@@ -55,19 +55,6 @@ export class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin impl
     isInitialConnection: boolean,
     connectFunc: () => Promise<ClientWrapper>
   ): Promise<ClientWrapper> {
-    return this.connectInternal(hostInfo, connectFunc);
-  }
-
-  override async forceConnect(
-    hostInfo: HostInfo,
-    props: Map<string, any>,
-    isInitialConnection: boolean,
-    forceConnectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    return this.connectInternal(hostInfo, forceConnectFunc);
-  }
-
-  async connectInternal(hostInfo: HostInfo, connectFunc: () => Promise<ClientWrapper>): Promise<ClientWrapper> {
     const targetClient = await connectFunc();
 
     if (targetClient) {

--- a/common/lib/plugins/efm/host_monitoring_connection_plugin.ts
+++ b/common/lib/plugins/efm/host_monitoring_connection_plugin.ts
@@ -53,25 +53,12 @@ export class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin imp
     return new Set<string>(["*"]);
   }
 
-  connect(
+  async connect(
     hostInfo: HostInfo,
     props: Map<string, any>,
     isInitialConnection: boolean,
     connectFunc: () => Promise<ClientWrapper>
   ): Promise<ClientWrapper> {
-    return this.connectInternal(hostInfo, connectFunc);
-  }
-
-  forceConnect(
-    hostInfo: HostInfo,
-    props: Map<string, any>,
-    isInitialConnection: boolean,
-    forceConnectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    return this.connectInternal(hostInfo, forceConnectFunc);
-  }
-
-  private async connectInternal(hostInfo: HostInfo, connectFunc: () => Promise<ClientWrapper>): Promise<ClientWrapper> {
     const targetClient = await connectFunc();
     if (targetClient != null) {
       const type: RdsUrlType = this.rdsUtils.identifyRdsType(hostInfo.host);

--- a/common/lib/plugins/efm2/host_monitoring2_connection_plugin.ts
+++ b/common/lib/plugins/efm2/host_monitoring2_connection_plugin.ts
@@ -52,25 +52,12 @@ export class HostMonitoring2ConnectionPlugin extends AbstractConnectionPlugin im
     return new Set<string>(["*"]);
   }
 
-  connect(
+  async connect(
     hostInfo: HostInfo,
     props: Map<string, any>,
     isInitialConnection: boolean,
     connectFunc: () => Promise<ClientWrapper>
   ): Promise<ClientWrapper> {
-    return this.connectInternal(hostInfo, connectFunc);
-  }
-
-  forceConnect(
-    hostInfo: HostInfo,
-    props: Map<string, any>,
-    isInitialConnection: boolean,
-    forceConnectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    return this.connectInternal(hostInfo, forceConnectFunc);
-  }
-
-  private async connectInternal(hostInfo: HostInfo, connectFunc: () => Promise<ClientWrapper>): Promise<ClientWrapper> {
     const targetClient = await connectFunc();
     if (targetClient != null) {
       const type: RdsUrlType = this.rdsUtils.identifyRdsType(hostInfo.host);

--- a/common/lib/plugins/failover/failover_plugin.ts
+++ b/common/lib/plugins/failover/failover_plugin.ts
@@ -52,7 +52,6 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
   private static readonly subscribedMethods: Set<string> = new Set([
     "initHostProvider",
     "connect",
-    "forceConnect",
     "query",
     "notifyConnectionChanged",
     "notifyHostListChanged"
@@ -242,34 +241,6 @@ export class FailoverPlugin extends AbstractConnectionPlugin {
   }
 
   override async connect(
-    hostInfo: HostInfo,
-    props: Map<string, any>,
-    isInitialConnection: boolean,
-    connectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    try {
-      return await this.connectInternal(hostInfo, props, isInitialConnection, connectFunc);
-    } catch (e: any) {
-      logger.debug(`Connect to ${hostInfo.host} failed with message: ${e.message}`);
-      throw e;
-    }
-  }
-
-  override async forceConnect(
-    hostInfo: HostInfo,
-    props: Map<string, any>,
-    isInitialConnection: boolean,
-    forceConnectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    try {
-      return await this.connectInternal(hostInfo, props, isInitialConnection, forceConnectFunc);
-    } catch (e: any) {
-      logger.debug(`Force connect to ${hostInfo.host} failed with message: ${e.message}`);
-      throw e;
-    }
-  }
-
-  async connectInternal(
     hostInfo: HostInfo,
     props: Map<string, any>,
     isInitialConnection: boolean,

--- a/common/lib/plugins/limitless/limitless_connection_context.ts
+++ b/common/lib/plugins/limitless/limitless_connection_context.ts
@@ -16,6 +16,7 @@
 
 import { HostInfo } from "../../host_info";
 import { ClientWrapper } from "../../client_wrapper";
+import { ConnectionPlugin } from "../../connection_plugin";
 
 export class LimitlessConnectionContext {
   private readonly hostInfo: HostInfo;
@@ -23,19 +24,22 @@ export class LimitlessConnectionContext {
   private connection: ClientWrapper | null;
   private readonly connectFunc: () => Promise<ClientWrapper>;
   private routers: HostInfo[] | null;
+  private plugin: ConnectionPlugin;
 
   constructor(
     hostInfo: HostInfo,
     props: Map<string, any>,
     connection: ClientWrapper | null,
     connectFunc: () => Promise<ClientWrapper>,
-    routers: HostInfo[] | null
+    routers: HostInfo[] | null,
+    plugin: ConnectionPlugin
   ) {
     this.hostInfo = hostInfo;
     this.props = props;
     this.connection = connection;
     this.connectFunc = connectFunc;
     this.routers = routers;
+    this.plugin = plugin;
   }
 
   public getHostInfo(): HostInfo {
@@ -64,5 +68,9 @@ export class LimitlessConnectionContext {
 
   public setRouters(routers: HostInfo[]) {
     this.routers = routers;
+  }
+
+  public getPlugin(): ConnectionPlugin {
+    return this.plugin;
   }
 }

--- a/common/lib/plugins/limitless/limitless_connection_plugin.ts
+++ b/common/lib/plugins/limitless/limitless_connection_plugin.ts
@@ -26,7 +26,6 @@ import { LimitlessHelper } from "./limitless_helper";
 
 export class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
   private static readonly subscribedMethods: Set<string> = new Set(["connect"]);
-  private static readonly internalConnectPropertyName: string = "784dd5c2-a77b-4c9f-a0a9-b4ea37395e6c";
   private readonly properties: Map<string, any>;
   private readonly pluginService: PluginService;
   private limitlessRouterService: LimitlessRouterService;
@@ -42,22 +41,7 @@ export class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
     return LimitlessConnectionPlugin.subscribedMethods;
   }
 
-  connect(
-    hostInfo: HostInfo,
-    props: Map<string, any>,
-    isInitialConnection: boolean,
-    connectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    if (props.get(LimitlessConnectionPlugin.internalConnectPropertyName)) {
-      return connectFunc();
-    }
-
-    const copyProps = new Map<string, any>(props);
-    copyProps.set(LimitlessConnectionPlugin.internalConnectPropertyName, true);
-    return this.connectInternal(hostInfo, copyProps, isInitialConnection, connectFunc);
-  }
-
-  private async connectInternal(
+  async connect(
     hostInfo: HostInfo,
     props: Map<string, any>,
     isInitialConnection: boolean,
@@ -77,7 +61,7 @@ export class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
       this.limitlessRouterService.startMonitor(hostInfo, props);
     }
 
-    const context = new LimitlessConnectionContext(hostInfo, props, conn, connectFunc, null);
+    const context = new LimitlessConnectionContext(hostInfo, props, conn, connectFunc, null, this);
     await this.limitlessRouterService.establishConnection(context);
 
     if (context.getConnection() != null) {

--- a/common/lib/plugins/limitless/limitless_router_service.ts
+++ b/common/lib/plugins/limitless/limitless_router_service.ts
@@ -117,7 +117,7 @@ export class LimitlessRouterServiceImpl implements LimitlessRouterService {
     }
 
     try {
-      context.setConnection(await this.pluginService.connect(selectedHostSpec, context.getProperties()));
+      context.setConnection(await this.pluginService.connect(selectedHostSpec, context.getProperties(), context.getPlugin()));
     } catch (e) {
       logger.debug(Messages.get("LimitlessRouterServiceImpl.failedToConnectToHost", selectedHostSpec.host));
       selectedHostSpec.setAvailability(HostAvailability.NOT_AVAILABLE);
@@ -179,7 +179,7 @@ export class LimitlessRouterServiceImpl implements LimitlessRouterService {
       }
 
       try {
-        context.setConnection(await this.pluginService.connect(selectedHostSpec, context.getProperties()));
+        context.setConnection(await this.pluginService.connect(selectedHostSpec, context.getProperties(), context.getPlugin()));
         if (context.getConnection()) {
           return;
         }

--- a/common/lib/plugins/read_write_splitting_plugin.ts
+++ b/common/lib/plugins/read_write_splitting_plugin.ts
@@ -119,19 +119,7 @@ export class ReadWriteSplittingPlugin extends AbstractConnectionPlugin implement
       const message: string = Messages.get("ReadWriteSplittingPlugin.unsupportedHostSelectorStrategy", this.readerSelectorStrategy);
       logAndThrowError(message);
     }
-    return await this.connectInternal(isInitialConnection, connectFunc);
-  }
 
-  forceConnect(
-    hostInfo: HostInfo,
-    props: Map<string, any>,
-    isInitialConnection: boolean,
-    forceConnectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    return this.connectInternal(isInitialConnection, forceConnectFunc);
-  }
-
-  private async connectInternal(isInitialConnection: boolean, connectFunc: () => Promise<ClientWrapper>): Promise<ClientWrapper> {
     const result = await connectFunc();
     if (!isInitialConnection || this._hostListProviderService?.isStaticHostListProvider()) {
       return result;
@@ -198,7 +186,7 @@ export class ReadWriteSplittingPlugin extends AbstractConnectionPlugin implement
     try {
       const copyProps = new Map<string, any>(props);
       WrapperProperties.ENABLE_CLUSTER_AWARE_FAILOVER.set(copyProps, false);
-      const targetClient = await this.pluginService.connect(writerHost, copyProps);
+      const targetClient = await this.pluginService.connect(writerHost, copyProps, this);
       this.isWriterClientFromInternalPool = targetClient instanceof PoolClientWrapper;
       this.setWriterClient(targetClient, writerHost);
       await this.switchCurrentTargetClientTo(this.writerTargetClient, writerHost);
@@ -292,7 +280,7 @@ export class ReadWriteSplittingPlugin extends AbstractConnectionPlugin implement
         try {
           const copyProps = new Map<string, any>(props);
           WrapperProperties.ENABLE_CLUSTER_AWARE_FAILOVER.set(copyProps, false);
-          targetClient = await this.pluginService.connect(host, copyProps);
+          targetClient = await this.pluginService.connect(host, copyProps, this);
           this.isReaderClientFromInternalPool = targetClient instanceof PoolClientWrapper;
           readerHost = host;
           break;

--- a/common/lib/plugins/stale_dns/stale_dns_plugin.ts
+++ b/common/lib/plugins/stale_dns/stale_dns_plugin.ts
@@ -25,7 +25,7 @@ import { ClientWrapper } from "../../client_wrapper";
 import { Messages } from "../../utils/messages";
 
 export class StaleDnsPlugin extends AbstractConnectionPlugin {
-  private static readonly subscribedMethods: Set<string> = new Set<string>(["initHostProvider", "connect", "forceConnect", "notifyHostListChanged"]);
+  private static readonly subscribedMethods: Set<string> = new Set<string>(["initHostProvider", "connect", "notifyHostListChanged"]);
   private pluginService: PluginService;
   private staleDnsHelper: StaleDnsHelper;
   private hostListProviderService?: HostListProviderService;
@@ -41,18 +41,6 @@ export class StaleDnsPlugin extends AbstractConnectionPlugin {
   }
 
   override async connect(
-    hostInfo: HostInfo,
-    properties: Map<string, any>,
-    isInitialConnection: boolean,
-    connectFunc: () => Promise<ClientWrapper>
-  ): Promise<ClientWrapper> {
-    if (!this.hostListProviderService) {
-      throw new AwsWrapperError(Messages.get("HostListProviderService.notFound"));
-    }
-    return await this.staleDnsHelper.getVerifiedConnection(hostInfo.host, isInitialConnection, this.hostListProviderService, properties, connectFunc);
-  }
-
-  override async forceConnect(
     hostInfo: HostInfo,
     properties: Map<string, any>,
     isInitialConnection: boolean,

--- a/common/lib/wrapper_property.ts
+++ b/common/lib/wrapper_property.ts
@@ -434,8 +434,7 @@ export class WrapperProperties {
     for (const key of props.keys()) {
       if (
         !key.startsWith(WrapperProperties.MONITORING_PROPERTY_PREFIX) &&
-        !key.startsWith(ClusterTopologyMonitorImpl.MONITORING_PROPERTY_PREFIX) &&
-        key !== Failover2Plugin.INTERNAL_CONNECT_PROPERTY_NAME
+        !key.startsWith(ClusterTopologyMonitorImpl.MONITORING_PROPERTY_PREFIX)
       ) {
         continue;
       }

--- a/mysql/lib/client.ts
+++ b/mysql/lib/client.ts
@@ -53,7 +53,7 @@ export class AwsMySQLClient extends AwsClient {
       if (hostInfo == null) {
         throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter"));
       }
-      const result: ClientWrapper = await this.pluginManager.connect(hostInfo, this.properties, true);
+      const result: ClientWrapper = await this.pluginManager.connect(hostInfo, this.properties, true, null);
       if (isDialectTopologyAware(this.pluginService.getDialect())) {
         try {
           const role = await this.pluginService.getHostRole(result);

--- a/pg/lib/client.ts
+++ b/pg/lib/client.ts
@@ -52,7 +52,7 @@ export class AwsPGClient extends AwsClient {
       if (hostInfo == null) {
         throw new AwsWrapperError(Messages.get("HostInfo.noHostParameter"));
       }
-      const result: ClientWrapper = await this.pluginManager.connect(hostInfo, this.properties, true);
+      const result: ClientWrapper = await this.pluginManager.connect(hostInfo, this.properties, true, null);
       if (isDialectTopologyAware(this.pluginService.getDialect())) {
         try {
           const role = await this.pluginService.getHostRole(result);

--- a/tests/unit/aurora_initial_connection_strategy_plugin.test.ts
+++ b/tests/unit/aurora_initial_connection_strategy_plugin.test.ts
@@ -110,7 +110,7 @@ describe("Aurora initial connection strategy plugin", () => {
   it("test writer - resolves to reader", async () => {
     when(mockRdsUtils.identifyRdsType(anything())).thenReturn(RdsUrlType.RDS_WRITER_CLUSTER);
     when(mockPluginService.getAllHosts()).thenReturn([hostInfoBuilder.withRole(HostRole.WRITER).build()]);
-    when(mockPluginService.connect(anything(), anything())).thenResolve(instance(readerClient));
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(instance(readerClient));
 
     expect(await plugin.connect(hostInfo, props, true, mockFunc)).toBe(undefined);
   });
@@ -119,7 +119,7 @@ describe("Aurora initial connection strategy plugin", () => {
     when(mockRdsUtils.identifyRdsType(anything())).thenReturn(RdsUrlType.RDS_WRITER_CLUSTER);
     when(mockPluginService.getAllHosts()).thenReturn([hostInfoBuilder.withRole(HostRole.WRITER).build()]);
     when(mockPluginService.getHostRole(writerClient)).thenReturn(Promise.resolve(HostRole.WRITER));
-    when(mockPluginService.connect(anything(), anything())).thenResolve(writerClient);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(writerClient);
 
     expect(await plugin.connect(hostInfo, props, true, mockFunc)).toBe(writerClient);
     verify(mockPluginService.forceRefreshHostList(writerClient)).never();
@@ -135,7 +135,7 @@ describe("Aurora initial connection strategy plugin", () => {
   it("test reader - resolves to reader", async () => {
     when(mockRdsUtils.identifyRdsType(anything())).thenReturn(RdsUrlType.RDS_READER_CLUSTER);
     when(mockPluginService.getHosts()).thenReturn([hostInfoBuilder.withRole(HostRole.READER).build()]);
-    when(mockPluginService.connect(anything(), anything())).thenResolve(readerClient);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(readerClient);
     when(mockPluginService.acceptsStrategy(anything(), anything())).thenReturn(true);
     when(mockPluginService.getHostRole(readerClient)).thenReturn(Promise.resolve(HostRole.READER));
     when(mockPluginService.getHostInfoByStrategy(anything(), anything())).thenReturn(instance(mockReaderHostInfo));
@@ -147,7 +147,7 @@ describe("Aurora initial connection strategy plugin", () => {
   it("test reader - resolves to writer", async () => {
     when(mockRdsUtils.identifyRdsType(anything())).thenReturn(RdsUrlType.RDS_READER_CLUSTER);
     when(mockPluginService.getHosts()).thenReturn([hostInfoBuilder.withRole(HostRole.READER).build()]);
-    when(mockPluginService.connect(anything(), anything())).thenResolve(writerClient);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(writerClient);
     when(mockPluginService.acceptsStrategy(anything(), anything())).thenReturn(true);
 
     expect(await plugin.connect(hostInfo, props, true, mockFuncUndefined)).toBe(undefined);
@@ -158,7 +158,7 @@ describe("Aurora initial connection strategy plugin", () => {
     when(mockPluginService.getAllHosts())
       .thenReturn([hostInfoBuilder.withRole(HostRole.READER).build()])
       .thenReturn([hostInfoBuilder.withRole(HostRole.WRITER).build()]);
-    when(mockPluginService.connect(anything(), anything())).thenResolve(writerClient);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(writerClient);
     when(mockPluginService.acceptsStrategy(anything(), anything())).thenReturn(true);
     when(mockPluginService.getHostRole(writerClient)).thenReturn(Promise.resolve(HostRole.WRITER));
     when(mockPluginService.getHostInfoByStrategy(anything(), anything())).thenReturn(instance(mockReaderHostInfo));

--- a/tests/unit/failover2_plugin.test.ts
+++ b/tests/unit/failover2_plugin.test.ts
@@ -21,7 +21,7 @@ import { HostInfo } from "../../common/lib/host_info";
 import { HostInfoBuilder } from "../../common/lib/host_info_builder";
 import { RdsHostListProvider } from "../../common/lib/host_list_provider/rds_host_list_provider";
 import { HostRole } from "../../common/lib/host_role";
-import { PluginServiceImpl } from "../../common/lib/plugin_service";
+import { PluginService, PluginServiceImpl } from "../../common/lib/plugin_service";
 import { FailoverMode } from "../../common/lib/plugins/failover/failover_mode";
 import {
   AwsWrapperError,
@@ -115,7 +115,7 @@ describe("reader failover handler", () => {
     when(mockPluginService.getHosts()).thenReturn(hosts);
     when(mockPluginService.getHostInfoByStrategy(HostRole.READER, anything(), anything())).thenReturn(mockHostInfo);
     when(mockPluginService.forceMonitoringRefresh(false, anything())).thenResolve(true);
-    when(mockPluginService.connect(anything(), anything())).thenResolve(mockClientWrapper);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(mockClientWrapper);
     when(mockPluginService.getHostRole(mockClientWrapper)).thenResolve(HostRole.READER);
     when(mockPluginService.getHostInfoBuilder()).thenReturn(builder);
 
@@ -140,7 +140,7 @@ describe("reader failover handler", () => {
     when(mockPluginService.getHosts()).thenReturn(hosts);
     when(mockPluginService.getAllHosts()).thenReturn(hosts);
     when(mockPluginService.forceMonitoringRefresh(true, anything())).thenResolve(true);
-    when(mockPluginService.connect(mockHostInfo, anything())).thenReject(test);
+    when(mockPluginService.connect(mockHostInfo, anything(), anything())).thenReject(test);
 
     const mockHostInfoInstance = instance(mockHostInfo);
     const mockPluginServiceInstance = instance(mockPluginService);
@@ -219,7 +219,7 @@ describe("reader failover handler", () => {
     when(mockPluginService.getHosts()).thenReturn(hosts);
     when(mockPluginService.getAllHosts()).thenReturn(hosts);
     when(mockPluginService.forceMonitoringRefresh(true, anything())).thenResolve(true);
-    when(mockPluginService.connect(hostInfo, anything())).thenResolve(mockClientWrapper);
+    when(mockPluginService.connect(hostInfo, anything(), anything())).thenResolve(mockClientWrapper);
     when(mockPluginService.getHostRole(mockClientWrapper)).thenResolve(HostRole.WRITER);
 
     const mockPluginServiceInstance = instance(mockPluginService);

--- a/tests/unit/failover_plugin.test.ts
+++ b/tests/unit/failover_plugin.test.ts
@@ -21,7 +21,7 @@ import { HostInfo } from "../../common/lib/host_info";
 import { HostInfoBuilder } from "../../common/lib/host_info_builder";
 import { RdsHostListProvider } from "../../common/lib/host_list_provider/rds_host_list_provider";
 import { HostRole } from "../../common/lib/host_role";
-import { PluginServiceImpl } from "../../common/lib/plugin_service";
+import { PluginService, PluginServiceImpl } from "../../common/lib/plugin_service";
 import { FailoverMode } from "../../common/lib/plugins/failover/failover_mode";
 import { FailoverPlugin } from "../../common/lib/plugins/failover/failover_plugin";
 import { ClusterAwareReaderFailoverHandler } from "../../common/lib/plugins/failover/reader_failover_handler";

--- a/tests/unit/read_write_splitting.test.ts
+++ b/tests/unit/read_write_splitting.test.ts
@@ -110,7 +110,7 @@ describe("reader write splitting test", () => {
     when(mockPluginService.getCurrentClient()).thenReturn(instance(mockWriterClient));
     when(await mockWriterClient.isValid()).thenReturn(true);
     when(mockPluginService.getCurrentHostInfo()).thenReturn(writerHost);
-    when(mockPluginService.connect(anything(), anything())).thenResolve(mockReaderWrapper);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(mockReaderWrapper);
 
     const target = new ReadWriteSplittingPlugin(
       mockPluginServiceInstance,
@@ -134,7 +134,7 @@ describe("reader write splitting test", () => {
     when(mockPluginService.getCurrentClient()).thenReturn(instance(mockReaderClient));
     when(await mockReaderClient.isValid()).thenReturn(true);
     when(mockPluginService.getCurrentHostInfo()).thenReturn(readerHost1);
-    when(mockPluginService.connect(anything(), anything())).thenResolve(mockWriterWrapper);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(mockWriterWrapper);
 
     const target = new ReadWriteSplittingPlugin(
       mockPluginServiceInstance,
@@ -158,7 +158,7 @@ describe("reader write splitting test", () => {
     when(mockPluginService.getCurrentClient()).thenReturn(instance(mockReaderClient));
     when(await mockReaderClient.isValid()).thenReturn(true);
     when(mockPluginService.getCurrentHostInfo()).thenReturn(readerHost1);
-    when(mockPluginService.connect(anything(), anything())).thenResolve(mockReaderWrapper);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(mockReaderWrapper);
 
     const target = new ReadWriteSplittingPlugin(
       mockPluginServiceInstance,
@@ -182,7 +182,7 @@ describe("reader write splitting test", () => {
     when(mockPluginService.getCurrentClient()).thenReturn(instance(mockWriterClient));
     when(await mockWriterClient.isValid()).thenReturn(true);
     when(mockPluginService.getCurrentHostInfo()).thenReturn(writerHost);
-    when(mockPluginService.connect(anything(), anything())).thenResolve(mockReaderWrapper);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(mockReaderWrapper);
 
     const target = new ReadWriteSplittingPlugin(
       mockPluginServiceInstance,
@@ -208,7 +208,7 @@ describe("reader write splitting test", () => {
     when(mockWriterClient.targetClient).thenReturn(mockWriterWrapper);
     when(mockWriterClient.targetClient && (await mockPluginService.isClientValid(mockWriterClient.targetClient))).thenReturn(true);
     when(mockPluginService.getCurrentHostInfo()).thenReturn(writerHost);
-    when(mockPluginService.connect(anything(), anything())).thenReturn(Promise.resolve(mockWriterWrapper));
+    when(mockPluginService.connect(anything(), anything(), anything())).thenReturn(Promise.resolve(mockWriterWrapper));
 
     const target = new ReadWriteSplittingPlugin(
       mockPluginServiceInstance,
@@ -410,7 +410,7 @@ describe("reader write splitting test", () => {
     when(await mockWriterClient.isValid()).thenReturn(true);
     when(mockPluginService.getCurrentHostInfo()).thenReturn(writerHost).thenReturn(writerHost).thenReturn(readerHost1);
     when(mockDriverDialect.connect(anything(), anything())).thenReturn(Promise.resolve(poolClientWrapper));
-    when(mockPluginService.connect(anything(), anything())).thenResolve(poolClientWrapper);
+    when(mockPluginService.connect(anything(), anything(), anything())).thenResolve(poolClientWrapper);
     const config: AwsPoolConfig = new AwsPoolConfig({
       idleTimeoutMillis: 7000,
       maxConnections: 10,
@@ -443,9 +443,9 @@ describe("reader write splitting test", () => {
       .thenReturn(readerHost1)
       .thenReturn(writerHost);
     when(mockDriverDialect.connect(anything(), anything())).thenReturn(Promise.resolve(poolClientWrapper));
-    when(mockPluginService.connect(writerHost, anything())).thenResolve(poolClientWrapper);
-    when(mockPluginService.connect(readerHost1, anything())).thenResolve(poolClientWrapper);
-    when(mockPluginService.connect(readerHost2, anything())).thenResolve(poolClientWrapper);
+    when(mockPluginService.connect(writerHost, anything(), anything())).thenResolve(poolClientWrapper);
+    when(mockPluginService.connect(readerHost1, anything(), anything())).thenResolve(poolClientWrapper);
+    when(mockPluginService.connect(readerHost2, anything(), anything())).thenResolve(poolClientWrapper);
 
     const config: AwsPoolConfig = new AwsPoolConfig({
       idleTimeoutMillis: 7000,


### PR DESCRIPTION
### Summary

improve forceConnect pipeline:
- review implemented forceConnect() for existing plugins
- keep forceConnect() for plugins related to db authentication; remove forceConnect() for other plugins
- allows to skip a particular plugin while calling connect() or forceConnect() pipeline

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
