### PR TITLE
fix: import paths for JS projects and circular dependency issue in RdsHostListProvider

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,10 @@
 {
   "plugins": [
     ["babel-plugin-transform-rewrite-imports", {
-      "appendExtension": ".js"
+      "appendExtension": ".js",
+      "replaceExtensions": {
+        "(.+?)/common/lib$": "$1/common/lib/index"
+      }
     }]
   ]
 }

--- a/common/lib/host_list_provider/rds_host_list_provider.ts
+++ b/common/lib/host_list_provider/rds_host_list_provider.ts
@@ -21,7 +21,7 @@ import { RdsUrlType } from "../utils/rds_url_type";
 import { RdsUtils } from "../utils/rds_utils";
 import { HostListProviderService } from "../host_list_provider_service";
 import { ConnectionUrlParser } from "../utils/connection_url_parser";
-import { AwsWrapperError } from "../";
+import { AwsWrapperError } from "../utils/errors";
 import { Messages } from "../utils/messages";
 import { WrapperProperties } from "../wrapper_property";
 import { logger } from "../../logutils";


### PR DESCRIPTION
### Summary

The import paths ending in `/common/lib` were incorrectly transformed to `/common/lib.js` in release packages, causing import issues in JS projects. This PR fixes the transformation mapping `/common/lib` to `/common/lib/index.js`

Also updates the import in RdsHostListProvider to fix a circular dependency issue.

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
