### PR TITLE
fix: remove attached error listeners when ending connections

### DIFF
--- a/pg/lib/abstract_pg_error_handler.ts
+++ b/pg/lib/abstract_pg_error_handler.ts
@@ -18,7 +18,6 @@ import { ErrorHandler } from "../../common/lib/error_handler";
 import { ClientWrapper } from "../../common/lib/client_wrapper";
 import { logger } from "../../common/logutils";
 import { Messages } from "../../common/lib/utils/messages";
-import { error } from "winston";
 
 export abstract class AbstractPgErrorHandler implements ErrorHandler {
   protected unexpectedError: Error | null = null;

--- a/pg/lib/client.ts
+++ b/pg/lib/client.ts
@@ -171,6 +171,7 @@ class BaseAwsPgClient extends AwsClient implements PGClient {
       this.properties,
       "end",
       () => {
+        this.pluginService.removeErrorListener(this.targetClient);
         const res = this.targetClient!.end();
         this.targetClient = undefined;
         this.isConnected = false;


### PR DESCRIPTION
### Summary

PG client was not properly removing attached error listeners when releasing connections.
This PR ensures listeners are removed before ending connections.

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
