### PR TITLE
refactor: remove duplicated getHostAndPort method

### DIFF
--- a/common/lib/host_info.ts
+++ b/common/lib/host_info.ts
@@ -65,10 +65,6 @@ export class HostInfo {
     return this.port != HostInfo.NO_PORT;
   }
 
-  getHostAndPort(): string {
-    return this.isPortSpecified() ? this.host + ":" + this.port : this.host;
-  }
-
   addAlias(...alias: string[]) {
     if (!alias || alias.length < 1) {
       return;

--- a/common/lib/host_list_provider/monitoring/cluster_topology_monitor.ts
+++ b/common/lib/host_list_provider/monitoring/cluster_topology_monitor.ts
@@ -528,9 +528,9 @@ export class HostMonitor {
     }
 
     const latestWriterHostInfo: HostInfo = hosts.find((x) => x.role === HostRole.WRITER);
-    if (latestWriterHostInfo && writerHostInfo && latestWriterHostInfo.getHostAndPort() !== writerHostInfo.getHostAndPort()) {
+    if (latestWriterHostInfo && writerHostInfo && latestWriterHostInfo.hostAndPort !== writerHostInfo.hostAndPort) {
       this.writerChanged = true;
-      logger.debug(Messages.get("HostMonitor.writerHostChanged", writerHostInfo.getHostAndPort(), latestWriterHostInfo.getHostAndPort()));
+      logger.debug(Messages.get("HostMonitor.writerHostChanged", writerHostInfo.hostAndPort, latestWriterHostInfo.hostAndPort));
       this.monitor.updateTopologyCache(hosts);
       logger.debug(logTopology(hosts, `[hostMonitor ${this.hostInfo.hostId}] `));
     }

--- a/common/lib/plugins/bluegreen/blue_green_interim_status.ts
+++ b/common/lib/plugins/bluegreen/blue_green_interim_status.ts
@@ -104,7 +104,7 @@ export class BlueGreenInterimStatus {
       this.startTopology == null
         ? ""
         : this.startTopology
-            .map((x) => x.getHostAndPort() + x.role)
+            .map((x) => x.hostAndPort + x.role)
             .sort()
             .join(",")
     );
@@ -114,7 +114,7 @@ export class BlueGreenInterimStatus {
       this.currentTopology == null
         ? ""
         : this.currentTopology
-            .map((x) => x.getHostAndPort() + x.role)
+            .map((x) => x.hostAndPort + x.role)
             .sort()
             .join(",")
     );

--- a/common/lib/plugins/bluegreen/blue_green_status_provider.ts
+++ b/common/lib/plugins/bluegreen/blue_green_status_provider.ts
@@ -874,7 +874,7 @@ export class BlueGreenStatusProvider {
     logger.debug(
       "Corresponding hosts:\n" +
         Array.from(this.correspondingHosts.entries())
-          .map(([key, value]) => `   ${key} -> ${value.right == null ? "<null>" : value.right.getHostAndPort()}`)
+          .map(([key, value]) => `   ${key} -> ${value.right == null ? "<null>" : value.right.hostAndPort}`)
           .join("\n")
     );
 

--- a/common/lib/plugins/bluegreen/routing/base_connect_routing.ts
+++ b/common/lib/plugins/bluegreen/routing/base_connect_routing.ts
@@ -25,7 +25,7 @@ import { PluginService } from "../../../plugin_service";
 export abstract class BaseConnectRouting extends BaseRouting implements ConnectRouting {
   isMatch(hostInfo: HostInfo, hostRole: BlueGreenRole): boolean {
     return (
-      (this.hostAndPort === null || this.hostAndPort === (hostInfo ?? hostInfo.getHostAndPort().toLowerCase())) &&
+      (this.hostAndPort === null || this.hostAndPort === (hostInfo ?? hostInfo.hostAndPort.toLowerCase())) &&
       (this.role === null || this.role === hostRole)
     );
   }

--- a/common/lib/plugins/bluegreen/routing/base_execute_routing.ts
+++ b/common/lib/plugins/bluegreen/routing/base_execute_routing.ts
@@ -24,7 +24,7 @@ import { ConnectionPlugin } from "../../../connection_plugin";
 export abstract class BaseExecuteRouting extends BaseRouting implements ExecuteRouting {
   isMatch(hostInfo: HostInfo, hostRole: BlueGreenRole): boolean {
     return (
-      (this.hostAndPort === null || this.hostAndPort === (hostInfo ?? hostInfo.getHostAndPort().toLowerCase())) &&
+      (this.hostAndPort === null || this.hostAndPort === (hostInfo ?? hostInfo.hostAndPort.toLowerCase())) &&
       (this.role === null || this.role === hostRole)
     );
   }

--- a/common/lib/plugins/bluegreen/routing/substitute_connect_routing.ts
+++ b/common/lib/plugins/bluegreen/routing/substitute_connect_routing.ts
@@ -99,12 +99,12 @@ export class SubstituteConnectRouting extends BaseConnectRouting {
         // try with another IAM host
       }
     }
-    throw new AwsWrapperError(Messages.get("Bgd.inProgressCantOpenConnection", this.substituteHost.getHostAndPort()));
+    throw new AwsWrapperError(Messages.get("Bgd.inProgressCantOpenConnection", this.substituteHost.hostAndPort));
   }
 
   toString(): string {
-    return `${this.constructor.name} [${this.hostAndPort ?? "<null>"}, ${this.role?.name ?? "<null>"}, substitute: ${this.substituteHost?.getHostAndPort() ?? "<null>"}, iamHosts: ${
-      this.iamHosts?.map((host) => host.getHostAndPort()).join(", ") ?? "<null>"
+    return `${this.constructor.name} [${this.hostAndPort ?? "<null>"}, ${this.role?.name ?? "<null>"}, substitute: ${this.substituteHost?.hostAndPort ?? "<null>"}, iamHosts: ${
+      this.iamHosts?.map((host) => host.hostAndPort).join(", ") ?? "<null>"
     }]`;
   }
 }

--- a/common/lib/plugins/connection_tracker/opened_connection_tracker.ts
+++ b/common/lib/plugins/connection_tracker/opened_connection_tracker.ts
@@ -36,7 +36,7 @@ export class OpenedConnectionTracker {
 
     // Check if the connection was established using an instance endpoint
     if (OpenedConnectionTracker.rdsUtils.isRdsInstance(hostInfo.host)) {
-      this.trackConnection(hostInfo.getHostAndPort(), client);
+      this.trackConnection(hostInfo.hostAndPort, client);
       return;
     }
 

--- a/common/lib/plugins/failover2/failover2_plugin.ts
+++ b/common/lib/plugins/failover2/failover2_plugin.ts
@@ -138,7 +138,7 @@ export class Failover2Plugin extends AbstractConnectionPlugin implements CanRele
       return await this._staleDnsHelper.getVerifiedConnection(hostInfo.host, isInitialConnection, this.hostListProviderService!, props, connectFunc);
     }
 
-    const hostInfoWithAvailability: HostInfo = this.pluginService.getHosts().find((x) => x.getHostAndPort() === hostInfo.getHostAndPort());
+    const hostInfoWithAvailability: HostInfo = this.pluginService.getHosts().find((x) => x.hostAndPort === hostInfo.hostAndPort);
 
     let client: ClientWrapper = null;
     if (!hostInfoWithAvailability || hostInfoWithAvailability.getAvailability() != HostAvailability.NOT_AVAILABLE) {


### PR DESCRIPTION
### Summary

There are two methods to get host and port. Remove one of the duplicate and keep the other one conforming to typescript's typical getter style.

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
