### PR TITLE
fix(pg): prevent process crash during Aurora failover

### DIFF
--- a/pg/lib/client.ts
+++ b/pg/lib/client.ts
@@ -358,7 +358,11 @@ class AwsPGPooledConnection extends BaseAwsPgClient {
           throw new UndefinedClientError();
         }
         this.pluginService.removeErrorListener(this.targetClient);
-        return await this.targetClient.client.release();
+        // After failover, the new target client may not have a release() method
+        // (e.g., a direct connection instead of a pooled connection).
+        if (typeof this.targetClient.client?.release === "function") {
+          return await this.targetClient.client.release();
+        }
       },
       null
     );

--- a/pg/lib/icp/pg_internal_pool_client.ts
+++ b/pg/lib/icp/pg_internal_pool_client.ts
@@ -25,6 +25,12 @@ export class AwsPgInternalPoolClient implements AwsInternalPoolClient {
 
   constructor(props: pkgPg.PoolConfig) {
     this.targetPool = new pkgPg.Pool(props);
+    // Handle idle client errors to prevent process crash during Aurora failover.
+    // When a failover occurs, idle connections in the pool are terminated by the server,
+    // which emits 'error' events. Without this handler, Node.js throws an uncaught exception.
+    this.targetPool.on("error", () => {
+      // Intentionally swallowed. The failover plugin will handle reconnection.
+    });
   }
 
   async end(): Promise<any> {


### PR DESCRIPTION
### Summary

resolve #620


### Description

Two issues cause Node.js process to crash when an Aurora failover occurs:

1. AwsPgInternalPoolClient creates a pg.Pool without an 'error' event handler. During failover, idle connections are terminated by the server, emitting 'error' events on the pool. Without a handler, Node.js throws an uncaught exception and the process exits.

2. AwsPGPooledConnection.release() unconditionally calls this.targetClient.client.release(), but after failover the new client may not have a release() method (e.g., a direct connection rather than a pooled connection), causing a TypeError.

Fix 1: Attach a no-op 'error' handler to the internal pg.Pool so idle connection errors are swallowed. The failover plugin handles reconnection.

Fix 2: Check if release() exists on the underlying client before calling it.


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
