### PR TITLE
fix: implement release method for AWS MySQL pool connections

### DIFF
--- a/common/lib/authentication/iam_authentication_plugin.ts
+++ b/common/lib/authentication/iam_authentication_plugin.ts
@@ -71,7 +71,7 @@ export class IamAuthenticationPlugin extends AbstractConnectionPlugin implements
   ): Promise<ClientWrapper> {
     const user = WrapperProperties.USER.get(props);
     if (!user) {
-      throw new AwsWrapperError(`${WrapperProperties.USER} is null or empty`);
+      throw new AwsWrapperError(`${WrapperProperties.USER.name} is null or empty`);
     }
 
     const host = IamAuthUtils.getIamHost(props, hostInfo);

--- a/mysql/lib/client.ts
+++ b/mysql/lib/client.ts
@@ -588,7 +588,7 @@ class AwsMySQLPooledConnection extends BaseAwsMySQLClient {
           throw new UndefinedClientError();
         }
         this.pluginService.removeErrorListener(this.targetClient);
-        return await this.targetClient.end();
+        return await ClientUtils.queryWithTimeout(this.targetClient.end(), this.properties);
       },
       null
     );

--- a/mysql/lib/client.ts
+++ b/mysql/lib/client.ts
@@ -577,6 +577,22 @@ class AwsMySQLPooledConnection extends BaseAwsMySQLClient {
   constructor(config: any, provider: ConnectionProvider) {
     super(config, provider);
   }
+
+  async release(): Promise<void> {
+    return this.pluginManager.execute(
+      this.pluginService.getCurrentHostInfo(),
+      this.properties,
+      "release",
+      async () => {
+        if (!this.targetClient) {
+          throw new UndefinedClientError();
+        }
+        this.pluginService.removeErrorListener(this.targetClient);
+        return await this.targetClient.end();
+      },
+      null
+    );
+  }
 }
 
 export type { AwsMySQLPooledConnection };


### PR DESCRIPTION
### Summary

Implement `release` method call for MySQL pooled connections, so that they can be released back into the pool.

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
