### PR TITLE
fix: add efm2 to the default plugin chain list for MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [2.1.1] - 2026-05-28
 
+### :magic_wand: Added
+
+- Added Aurora Initial Connection Strategy Plugin as one of default plugins enabled. To learn more about the plugin, [see the documentation here.](https://github.com/aws/aws-advanced-nodejs-wrapper/blob/main/docs/using-the-nodejs-wrapper/using-plugins/UsingTheAuroraInitialConnectionStrategyPlugin.md)
+
 ### :bug: Fixed
 
 - Prevent process crash during Aurora failover when using the PostgreSQL client, addresses [issue #620](https://github.com/aws/aws-advanced-nodejs-wrapper/issues/620) ([PR #621](https://github.com/aws/aws-advanced-nodejs-wrapper/pull/621)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### :bug: Fixed
 
-- Use a MySQL-specific default plugin chain when the driver dialect is MySQL2, excluding the `efm2` plugin from the defaults.
 - Prevent process crash during Aurora failover when using the PostgreSQL client, addresses [issue #620](https://github.com/aws/aws-advanced-nodejs-wrapper/issues/620) ([PR #621](https://github.com/aws/aws-advanced-nodejs-wrapper/pull/621)).
 
 ## [2.1.0] - 2026-01-15

--- a/common/lib/connection_plugin_chain_builder.ts
+++ b/common/lib/connection_plugin_chain_builder.ts
@@ -123,12 +123,9 @@ export class ConnectionPluginChainBuilder {
     } else {
       let pluginCodes: string = props.get(WrapperProperties.PLUGINS.name);
       if (pluginCodes == null) {
-        pluginCodes =
-          pluginService.getDriverDialect().getDialectName() === "MySQL2DriverDialect"
-            ? WrapperProperties.MYSQL2_DEFAULT_PLUGINS
-            : WrapperProperties.DEFAULT_PLUGINS;
+        pluginCodes = WrapperProperties.DEFAULT_PLUGINS;
       }
-      usingDefault = pluginCodes === WrapperProperties.DEFAULT_PLUGINS || pluginCodes === WrapperProperties.MYSQL2_DEFAULT_PLUGINS;
+      usingDefault = pluginCodes === WrapperProperties.DEFAULT_PLUGINS;
 
       pluginCodes = pluginCodes.trim();
       if (pluginCodes !== "") {

--- a/common/lib/wrapper_property.ts
+++ b/common/lib/wrapper_property.ts
@@ -47,7 +47,6 @@ export class WrapperProperty<T> {
 export class WrapperProperties {
   static readonly MONITORING_PROPERTY_PREFIX: string = "monitoring_";
   static readonly DEFAULT_PLUGINS = "initialConnection,auroraConnectionTracker,failover2,efm2";
-  static readonly MYSQL2_DEFAULT_PLUGINS = "initialConnection,auroraConnectionTracker,failover2";
   static readonly DEFAULT_TOKEN_EXPIRATION_SEC = 15 * 60;
 
   static readonly PLUGINS = new WrapperProperty<string>(


### PR DESCRIPTION
### Summary

Add EFM2 back to the default plugin chain list for MySQL

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
