### PR TITLE
chore: tag test resources

### DIFF
--- a/tests/integration/container/tests/custom_endpoint.test.ts
+++ b/tests/integration/container/tests/custom_endpoint.test.ts
@@ -35,6 +35,7 @@ import { logger } from "../../../../common/logutils";
 import { ProxyHelper } from "./utils/proxy_helper";
 import { PluginManager } from "../../../../index";
 import { TestDriver } from "./utils/test_driver";
+import { getResourceTags } from "./utils/test_tags";
 
 const itIf =
   features.includes(TestEnvironmentFeatures.FAILOVER_SUPPORTED) &&
@@ -97,7 +98,8 @@ async function createEndpoint(clusterId: string, instances: TestInstanceInfo[], 
     DBClusterEndpointIdentifier: endpointId,
     DBClusterIdentifier: clusterId,
     EndpointType: endpointType,
-    StaticMembers: instanceIds
+    StaticMembers: instanceIds,
+    Tags: getResourceTags()
   };
   const createEndpointCommand = new CreateDBClusterEndpointCommand(input);
   await rdsClient.send(createEndpointCommand);

--- a/tests/integration/container/tests/secrets_manager.test.ts
+++ b/tests/integration/container/tests/secrets_manager.test.ts
@@ -26,6 +26,7 @@ import { CreateSecretCommand, CreateSecretCommandOutput, DeleteSecretCommand, Se
 import { RDSClient } from "@aws-sdk/client-rds";
 import { AuroraTestUtility } from "./utils/aurora_test_utility";
 import { ProxyHelper } from "./utils/proxy_helper";
+import { getResourceTags } from "./utils/test_tags";
 
 const itIf =
   !features.includes(TestEnvironmentFeatures.PERFORMANCE) &&
@@ -84,7 +85,8 @@ async function createCommand(secretName: string) {
   const input = {
     Name: secretName,
     ForceOverwriteReplicaSecret: true,
-    SecretString: JSON.stringify(secretObj)
+    SecretString: JSON.stringify(secretObj),
+    Tags: getResourceTags()
   };
 
   const command = new CreateSecretCommand(input);

--- a/tests/integration/container/tests/utils/aurora_test_utility.ts
+++ b/tests/integration/container/tests/utils/aurora_test_utility.ts
@@ -42,6 +42,7 @@ import { TestInstanceInfo } from "./test_instance_info";
 import { TestEnvironmentInfo } from "./test_environment_info";
 import { DatabaseEngine } from "./database_engine";
 import { DatabaseEngineDeployment } from "./database_engine_deployment";
+import { getResourceTags } from "./test_tags";
 
 const instanceClass: string = "db.r5.large";
 
@@ -367,7 +368,8 @@ export class AuroraTestUtility {
       DBInstanceClass: instanceClass,
       PubliclyAccessible: true,
       Engine: info.databaseEngine,
-      EngineVersion: info.databaseEngineVersion
+      EngineVersion: info.databaseEngineVersion,
+      Tags: getResourceTags()
     });
     try {
       await this.client.send(command);

--- a/tests/integration/container/tests/utils/test_tags.ts
+++ b/tests/integration/container/tests/utils/test_tags.ts
@@ -1,0 +1,34 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { Tag } from "@aws-sdk/client-rds";
+
+/**
+ * Returns a consistent set of AWS resource tags for test-created resources.
+ * This enables identification, cost tracking, and automated cleanup of
+ * resources created by integration test runs.
+ */
+export function getResourceTags(): Tag[] {
+  const now = new Date();
+  // Use ISO-like format with only tag-safe characters (no commas or special chars)
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const timeStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+
+  return [
+    { Key: "env", Value: "test-runner" },
+    { Key: "created", Value: timeStr }
+  ];
+}


### PR DESCRIPTION
### Summary

Adds AWS resource tags to all test resources created during Node.js integration test execution.

### Description

AuroraTestUtility.java already tags resources it provisions (clusters, instances) with env=test-runner and created=<timestamp>. However, resources created by the Node.js tests themselves were being created without any tags. This adds tags to the creation of:
- DB instances (autoscaling tests)
- custom cluster endpoints
- Secrets Manager secrets 


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
