### PR TITLE
chore: switch to trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
-      packages: write
     steps:
       - name: "Clone Repository"
         uses: actions/checkout@v4
       - name: "Set up Node.js"
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - name: "Install dependencies"
         run: npm install --no-save
@@ -27,5 +27,3 @@ jobs:
         run: npm test
       - run: npm ci
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Summary

Switch from temporary token to the trusted publishing release workflow: https://docs.npmjs.com/trusted-publishers

### Description

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
