### PR TITLE
fix: add configuration types and correct runtime dependencies

### DIFF
--- a/common/lib/authentication/aws_credentials_manager.ts
+++ b/common/lib/authentication/aws_credentials_manager.ts
@@ -21,7 +21,7 @@ import { WrapperProperties } from "../wrapper_property";
 import { AwsWrapperError } from "../utils/errors";
 import { Messages } from "../utils/messages";
 
-interface AwsCredentialsProviderHandler {
+export interface AwsCredentialsProviderHandler {
   getAwsCredentialsProvider(hostInfo: HostInfo, properties: Map<string, any>): AwsCredentialIdentityProvider;
 }
 

--- a/common/lib/session_state_client.ts
+++ b/common/lib/session_state_client.ts
@@ -27,7 +27,7 @@ export interface SessionStateClient {
 
   setTransactionIsolation(level: TransactionIsolationLevel): Promise<any | void>;
 
-  getTransactionIsolation(): TransactionIsolationLevel;
+  getTransactionIsolation(): TransactionIsolationLevel | undefined;
 
   setSchema(schema: any): Promise<any | void>;
 

--- a/common/lib/wrapper_property.ts
+++ b/common/lib/wrapper_property.ts
@@ -14,8 +14,10 @@
   limitations under the License.
 */
 
+import type { AgentOptions } from "node:https";
 import { ConnectionProvider } from "./connection_provider";
 import { DatabaseDialect } from "./database_dialect/database_dialect";
+import type { AwsCredentialsProviderHandler } from "./authentication/aws_credentials_manager";
 import { AwsWrapperError } from "./utils/errors";
 import { Messages } from "./utils/messages";
 
@@ -75,7 +77,7 @@ export interface AwsClientConfig {
   /** The IAM user used to access the database */
   dbUser?: string;
   /** The options to be passed into the httpsAgent */
-  httpsAgentOptions?: Record<string, any>;
+  httpsAgentOptions?: AgentOptions;
   /** The name or the ARN of the secret to retrieve. */
   secretId?: string;
   /** The region of the secret to retrieve. */
@@ -153,7 +155,7 @@ export interface AwsClientConfig {
   /** A reference to a custom database dialect object. */
   customDatabaseDialect?: DatabaseDialect;
   /** A reference to a custom AwsCredentialsProviderHandler object. */
-  customAwsCredentialProviderHandler?: any;
+  customAwsCredentialProviderHandler?: AwsCredentialsProviderHandler;
   /** Name of the AWS Profile to use for IAM or SecretsManager auth. */
   awsProfile?: string;
   /** Driver configuration profile name */
@@ -377,11 +379,7 @@ export class WrapperProperties {
 
   static readonly DB_USER = new WrapperProperty<string>("dbUser", "The IAM user used to access the database", null);
 
-  static readonly HTTPS_AGENT_OPTIONS = new WrapperProperty<Record<string, any>>(
-    "httpsAgentOptions",
-    "The options to be passed into the httpsAgent",
-    null
-  );
+  static readonly HTTPS_AGENT_OPTIONS = new WrapperProperty<AgentOptions>("httpsAgentOptions", "The options to be passed into the httpsAgent", null);
 
   static readonly SECRET_ID = new WrapperProperty<string>("secretId", "The name or the ARN of the secret to retrieve.", null);
   static readonly SECRET_REGION = new WrapperProperty<string>("secretRegion", "The region of the secret to retrieve.", null);
@@ -650,7 +648,7 @@ export class WrapperProperties {
     null
   );
 
-  static readonly CUSTOM_AWS_CREDENTIAL_PROVIDER_HANDLER = new WrapperProperty<any>(
+  static readonly CUSTOM_AWS_CREDENTIAL_PROVIDER_HANDLER = new WrapperProperty<AwsCredentialsProviderHandler>(
     "customAwsCredentialProviderHandler",
     "A reference to a custom AwsCredentialsProviderHandler object.",
     null

--- a/common/lib/wrapper_property.ts
+++ b/common/lib/wrapper_property.ts
@@ -19,6 +19,209 @@ import { DatabaseDialect } from "./database_dialect/database_dialect";
 import { AwsWrapperError } from "./utils/errors";
 import { Messages } from "./utils/messages";
 
+export interface AwsClientConfig {
+  /** Comma separated list of connection plugin codes */
+  plugins?: string;
+  /** This flag is enabled by default, meaning that the plugins order will be automatically adjusted. Disable it at your own risk or if you really need plugins to be executed in a particular order. */
+  autoSortWrapperPluginOrder?: boolean;
+  /** A unique identifier for the supported database dialect. */
+  dialect?: string;
+  /** The connection provider used to create connections. */
+  connectionProvider?: ConnectionProvider;
+  /** Timeout in milliseconds for the wrapper to execute queries against MySQL database engines */
+  mysqlQueryTimeout?: number;
+  /** Timeout in milliseconds for the wrapper to create a connection. */
+  wrapperConnectTimeout?: number;
+  /** Timeout in milliseconds for the wrapper to execute queries. */
+  wrapperQueryTimeout?: number;
+  /** Enables session state transfer to a new connection. */
+  transferSessionStateOnSwitch?: boolean;
+  /** Enables resetting a connection's session state before closing it. */
+  resetSessionStateOnClose?: boolean;
+  /** Enables to rollback a current transaction being in progress when switching to a new connection. */
+  rollbackOnSwitch?: boolean;
+  /** An override for specifying the default host availability change strategy. */
+  defaultHostAvailabilityStrategy?: string;
+  /** Max number of retries for checking a host's availability. */
+  hostAvailabilityStrategyMaxRetries?: number;
+  /** The initial backoff time in seconds. */
+  hostAvailabilityStrategyInitialBackoffTimeSec?: number;
+  /** Interval in millis between measuring response time to a database host. */
+  responseMeasurementIntervalMs?: number;
+  /** Overrides the host that is used to generate the IAM token */
+  iamHost?: string;
+  /** Overrides default port that is used to generate the IAM token */
+  iamDefaultPort?: number;
+  /** Overrides AWS region that is used to generate the IAM token */
+  iamRegion?: string;
+  /** The ARN of the IAM Role that is to be assumed. */
+  iamRoleArn?: string;
+  /** The ARN of the identity provider */
+  iamIdpArn?: string;
+  /** IAM token cache expiration in seconds */
+  iamTokenExpiration?: number;
+  /** The federated user name */
+  idpUsername?: string;
+  /** The federated user password */
+  idpPassword?: string;
+  /** The hosting URL of the Identity Provider */
+  idpEndpoint?: string;
+  /** The hosting port of the Identity Provider */
+  idpPort?: number;
+  /** The ID of the AWS application configured on Okta */
+  appId?: string;
+  /** The relaying party identifier */
+  rpIdentifier?: string;
+  /** The IAM user used to access the database */
+  dbUser?: string;
+  /** The options to be passed into the httpsAgent */
+  httpsAgentOptions?: Record<string, any>;
+  /** The name or the ARN of the secret to retrieve. */
+  secretId?: string;
+  /** The region of the secret to retrieve. */
+  secretRegion?: string;
+  /** The endpoint of the secret to retrieve. */
+  secretEndpoint?: string;
+  /** Cluster topology refresh rate in millis during a writer failover process. During the writer failover process, cluster topology may be refreshed at a faster pace than normal to speed up discovery of the newly promoted writer. */
+  failoverClusterTopologyRefreshRateMs?: number;
+  /** Maximum allowed time for the failover process. */
+  failoverTimeoutMs?: number;
+  /** Interval of time to wait between attempts to reconnect to a failed writer during a writer failover process. */
+  failoverWriterReconnectIntervalMs?: number;
+  /** Reader connection attempt timeout during a reader failover process. */
+  failoverReaderConnectTimeoutMs?: number;
+  /** Enable/disable cluster-aware failover logic. */
+  enableClusterAwareFailover?: boolean;
+  /** Set host role to follow during failover. */
+  failoverMode?: string;
+  /** The strategy that should be used to select a new reader host while opening a new connection. */
+  failoverReaderHostSelectorStrategy?: string;
+  /** Cluster topology refresh rate in millis. The cached topology for the cluster will be invalidated after the specified time, after which it will be updated during the next interaction with the connection. */
+  clusterTopologyRefreshRateMs?: number;
+  /** Cluster topology high refresh rate in millis. */
+  clusterTopologyHighRefreshRateMs?: number;
+  /** A unique identifier for the cluster. Connections with the same cluster id share a cluster topology cache. If unspecified, a cluster id is automatically created for AWS RDS clusters. */
+  clusterId?: string;
+  /** The cluster instance DNS pattern that will be used to build a complete instance endpoint. A "?" character in this pattern should be used as a placeholder for cluster instance names. This pattern is required to be specified for IP address or custom domain connections to AWS RDS clusters. Otherwise, if unspecified, the pattern will be automatically created for AWS RDS clusters. */
+  clusterInstanceHostPattern?: string;
+  /** Set to true if you are providing a connection string with multiple comma-delimited hosts and your cluster has only one writer. The writer must be the first host in the connection string */
+  singleWriterConnectionString?: boolean;
+  /** The strategy that should be used to select a new reader host. */
+  readerHostSelectorStrategy?: string;
+  /** Maximum allowed time for the retries opening a connection. */
+  openConnectionRetryTimeoutMs?: number;
+  /** Time between each retry of opening a connection. */
+  openConnectionRetryIntervalMs?: number;
+  /** Interval in millis between sending SQL to the server and the first probe to database host. */
+  failureDetectionTime?: number;
+  /** Enable enhanced failure detection logic. */
+  failureDetectionEnabled?: boolean;
+  /** Interval in millis between probes to database host. */
+  failureDetectionInterval?: number;
+  /** Number of failed connection checks before considering database host unhealthy. */
+  failureDetectionCount?: number;
+  /** Interval in milliseconds for a monitor to be considered inactive and to be disposed. */
+  monitorDisposalTime?: number;
+  /** Comma separated list of database host-weight pairs in the format of `<host>:<weight>`. */
+  roundRobinHostWeightPairs?: string;
+  /** The default weight for any hosts that have not been configured with the `roundRobinHostWeightPairs` parameter. */
+  roundRobinDefaultWeight?: number;
+  /** Enables telemetry and observability of the wrapper */
+  enableTelemetry?: boolean;
+  /** Force submitting traces related to calls as top level traces. */
+  telemetrySubmitToplevel?: boolean;
+  /** Method to export telemetry traces of the wrapper. */
+  telemetryTracesBackend?: string;
+  /** Method to export telemetry metrics of the wrapper. */
+  telemetryMetricsBackend?: string;
+  /** Post an additional top-level trace for failover process. */
+  telemetryFailoverAdditionalTopTrace?: boolean;
+  /** If the cache of transaction router info is empty and a new connection is made, this property toggles whether the plugin will wait and synchronously fetch transaction router info before selecting a transaction router to connect to, or to fall back to using the provided DB Shard Group endpoint URL. */
+  limitlessWaitForTransactionRouterInfo?: boolean;
+  /** Interval in millis between retries fetching Limitless Transaction Router information. */
+  limitlessGetTransactionRouterInfoRetryIntervalMs?: number;
+  /** Max number of connection retries fetching Limitless Transaction Router information. */
+  limitlessGetTransactionRouterInfoMaxRetries?: number;
+  /** Interval in millis between polling for Limitless Transaction Routers to the database. */
+  limitlessTransactionRouterMonitorIntervalMs?: number;
+  /** Max number of connection retries the Limitless Connection Plugin will attempt. */
+  limitlessConnectMaxRetries?: number;
+  /** Interval in milliseconds for an Limitless router monitor to be considered inactive and to be disposed. */
+  limitlessTransactionRouterMonitorDisposalTimeMs?: number;
+  /** Map containing any keepAlive properties that the target driver accepts in the client configuration. */
+  wrapperKeepAliveProperties?: Map<string, any>;
+  /** A reference to a custom database dialect object. */
+  customDatabaseDialect?: DatabaseDialect;
+  /** A reference to a custom AwsCredentialsProviderHandler object. */
+  customAwsCredentialProviderHandler?: any;
+  /** Name of the AWS Profile to use for IAM or SecretsManager auth. */
+  awsProfile?: string;
+  /** Driver configuration profile name */
+  profileName?: string;
+  /** Controls how frequently custom endpoint monitors fetch custom endpoint info, in milliseconds. */
+  customEndpointInfoRefreshRateMs?: number;
+  /** Controls whether to wait for custom endpoint info to become available before connecting or executing a method. Waiting is only necessary if a connection to a given custom endpoint has not been opened or used recently. Note that disabling this may result in occasional connections to instances outside of the custom endpoint. */
+  waitForCustomEndpointInfo?: boolean;
+  /** Controls the maximum amount of time that the plugin will wait for custom endpoint info to be made available by the custom endpoint monitor, in milliseconds. */
+  waitForCustomEndpointInfoTimeoutMs?: number;
+  /** Controls how long a monitor should run without use before expiring and being removed, in milliseconds. */
+  customEndpointMonitorExpirationMs?: number;
+  /** The region of the cluster's custom endpoints. If not specified, the region will be parsed from the URL. */
+  customEndpointRegion?: string;
+  /** Enables replacing a green host name with the original hostname after a blue/green switchover and the green name no longer resolves. */
+  enableGreenHostReplacement?: boolean;
+  /** Connect timeout in milliseconds during Blue/Green Deployment switchover. */
+  bgConnectTimeoutMs?: number;
+  /** Blue/Green Deployment ID */
+  bgdId?: string;
+  /** Baseline Blue/Green Deployment status checking interval in milliseconds. */
+  bgBaselineMs?: number;
+  /** Increased Blue/Green Deployment status checking interval in milliseconds. */
+  bgIncreasedMs?: number;
+  /** High Blue/Green Deployment status checking interval in milliseconds. */
+  bgHighMs?: number;
+  /** Blue/Green Deployment switchover timeout in milliseconds. */
+  bgSwitchoverTimeoutMs?: number;
+  /** Enables Blue/Green Deployment switchover to suspend new blue connection requests while the switchover process is in progress. */
+  bgSuspendNewBlueConnections?: boolean;
+  /** Secrets Manager credentials' expiration time in seconds. */
+  secretExpirationSec?: number;
+  /** The key in the JSON secret that contains the username for the database connection. */
+  secretUsernameProperty?: string;
+  /** The key in the JSON secret that contains the password for the database connection. */
+  secretPasswordProperty?: string;
+  /** The time in milliseconds to keep a reader connection alive in the cache. A value of 0 means the same cached reader connection is reused indefinitely. */
+  cachedReaderKeepAliveTimeoutMs?: number;
+  /** Defines the priority for monitoring connections. Determines which type of node the topology monitor connects to (strict-writer, strict-reader, writer-or-reader). */
+  monitoringConnectionPriority?: string;
+  /** Comma-separated list of cluster instance DNS patterns used to build complete instance endpoints for Global Aurora Databases. A "?" is a placeholder for cluster instance names. Format: region1:pattern1,region2:pattern2 */
+  globalClusterInstanceHostPatterns?: string;
+  /** Comma-separated list of AWS regions accessible from this application. Restricts Global Aurora Database operations (topology, failover candidates, read/write splitting) to the listed regions. */
+  gdbAccessibleRegions?: string;
+  /** Defines the priority for monitoring connections in a Global Aurora Database context (e.g. strict-writer-primary, strict-reader-secondary, or a specific AWS region name). */
+  gdbMonitoringConnectionPriority?: string;
+  /** The home region for read/write splitting. */
+  gdbRwHomeRegion?: string;
+  /** Prevents connections to a reader node outside of the defined home region. */
+  gdbRwRestrictReaderToHomeRegion?: boolean;
+  /** Prevents connections to a writer node outside of the defined home region. */
+  gdbRwRestrictWriterToHomeRegion?: boolean;
+  /** Home region for Global Aurora Database failover. */
+  failoverHomeRegion?: string;
+  /** Host role to follow during failover when the GDB primary region is in the home region. */
+  activeHomeFailoverMode?: string;
+  /** Host role to follow during failover when the GDB primary region is not in the home region. */
+  inactiveHomeFailoverMode?: string;
+  /** Defines whether the inactive cluster writer endpoint in the initial connection URL should be replaced with a writer instance URL from the topology info when available (writer, none). */
+  inactiveClusterWriterEndpointSubstitutionRole?: string;
+  /** Allows avoiding the connection check for an inactive cluster writer endpoint. */
+  skipInactiveWriterClusterEndpointCheck?: boolean;
+  /** Defines whether the inactive cluster writer connection should be verified to be a writer, or if no role verification should be performed (writer, none). */
+  verifyInactiveClusterWriterEndpointConnectionType?: string;
+  /** Defines whether an opened connection should be verified to be a writer or reader, or if no role verification should be performed (writer, reader, none). */
+  verifyOpenedConnectionType?: string;
+}
+
 export class WrapperProperty<T> {
   name: string;
   description: string;

--- a/docs/using-the-nodejs-wrapper/using-plugins/UsingTheFederatedAuthPlugin.md
+++ b/docs/using-the-nodejs-wrapper/using-plugins/UsingTheFederatedAuthPlugin.md
@@ -7,8 +7,12 @@ Currently, Microsoft Active Directory Federation Services (AD FS) and Okta are s
 
 - This plugin requires the following packages to be installed:
   - [@aws-sdk/rds-signer](https://www.npmjs.com/package/@aws-sdk/rds-signer)
-  - [aws-sdk](https://www.npmjs.com/package/aws-sdk)
+  - [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
+  - [@aws-sdk/client-sts](https://www.npmjs.com/package/@aws-sdk/client-sts)
+  - [axios](https://www.npmjs.com/package/axios)
   - [axios-cookiejar-support](https://www.npmjs.com/package/axios-cookiejar-support)
+  - [http-cookie-agent](https://www.npmjs.com/package/http-cookie-agent)
+  - [tough-cookie](https://www.npmjs.com/package/tough-cookie)
   - [entities](https://www.npmjs.com/package/entities)
 
 ## What is Federated Identity

--- a/docs/using-the-nodejs-wrapper/using-plugins/UsingTheOktaAuthPlugin.md
+++ b/docs/using-the-nodejs-wrapper/using-plugins/UsingTheOktaAuthPlugin.md
@@ -6,7 +6,8 @@ The Okta Authentication Plugin adds support for authentication via Federated Ide
 
 - This plugin requires the following packages to be installed:
   - [@aws-sdk/rds-signer](https://www.npmjs.com/package/@aws-sdk/rds-signer)
-  - [aws-sdk](https://www.npmjs.com/package/aws-sdk)
+  - [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
+  - [@aws-sdk/client-sts](https://www.npmjs.com/package/@aws-sdk/client-sts)
   - [axios](https://www.npmjs.com/package/axios)
   - [entities](https://www.npmjs.com/package/entities)
 

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,7 @@ export { StaleDnsPlugin } from "./common/lib/plugins/stale_dns/stale_dns_plugin"
 export { ErrorSimulatorManager } from "./common/lib/plugins/dev/error_simulator_manager";
 
 export type { CanReleaseResources } from "./common/lib/can_release_resources";
+export type { AwsCredentialsProviderHandler } from "./common/lib/authentication/aws_credentials_manager";
 export type { ConnectionPlugin } from "./common/lib/connection_plugin";
 export type { ConnectionProvider } from "./common/lib/connection_provider";
 export type { HostSelector } from "./common/lib/host_selector";

--- a/mysql.ts
+++ b/mysql.ts
@@ -17,3 +17,4 @@
 export { AwsMySQLClient, AwsMySQLPoolClient } from "./mysql/lib/index";
 export type { AwsMySQLPooledConnection, AwsMySQLClientConfig } from "./mysql/lib/index";
 export type { AwsClientConfig } from "./common/lib/wrapper_property";
+export type { AwsCredentialsProviderHandler } from "./common/lib/authentication/aws_credentials_manager";

--- a/mysql.ts
+++ b/mysql.ts
@@ -15,4 +15,5 @@
 */
 
 export { AwsMySQLClient, AwsMySQLPoolClient } from "./mysql/lib/index";
-export type { AwsMySQLPooledConnection } from "./mysql/lib/index";
+export type { AwsMySQLPooledConnection, AwsMySQLClientConfig } from "./mysql/lib/index";
+export type { AwsClientConfig } from "./common/lib/wrapper_property";

--- a/mysql/lib/client.ts
+++ b/mysql/lib/client.ts
@@ -44,6 +44,9 @@ import { isDialectTopologyAware } from "../../common/lib/database_dialect/topolo
 import { MySQLClient, MySQLPoolClient } from "./mysql_client";
 import { DriverConnectionProvider } from "../../common/lib/driver_connection_provider";
 import { GlobalAuroraMySQLDatabaseDialect } from "./dialect/global_aurora_mysql_database_dialect";
+import { AwsClientConfig } from "../../common/lib/wrapper_property";
+
+export interface AwsMySQLClientConfig extends ConnectionOptions, AwsClientConfig {}
 
 class BaseAwsMySQLClient extends AwsClient implements MySQLClient {
   private static readonly knownDialectsByCode: Map<string, DatabaseDialect> = new Map([
@@ -54,7 +57,7 @@ class BaseAwsMySQLClient extends AwsClient implements MySQLClient {
     [DatabaseDialectCodes.RDS_MULTI_AZ_MYSQL, new RdsMultiAZClusterMySQLDatabaseDialect()]
   ]);
 
-  constructor(config: any, connectionProvider?: ConnectionProvider) {
+  constructor(config: AwsMySQLClientConfig, connectionProvider?: ConnectionProvider) {
     super(
       config,
       DatabaseType.MYSQL,
@@ -578,13 +581,13 @@ class BaseAwsMySQLClient extends AwsClient implements MySQLClient {
 }
 
 export class AwsMySQLClient extends BaseAwsMySQLClient {
-  constructor(config: any) {
+  constructor(config: AwsMySQLClientConfig) {
     super(config, new DriverConnectionProvider());
   }
 }
 
 class AwsMySQLPooledConnection extends BaseAwsMySQLClient {
-  constructor(config: any, provider: ConnectionProvider) {
+  constructor(config: AwsMySQLClientConfig, provider: ConnectionProvider) {
     super(config, provider);
   }
 
@@ -609,10 +612,10 @@ export type { AwsMySQLPooledConnection };
 
 export class AwsMySQLPoolClient implements MySQLPoolClient {
   private readonly connectionProvider: InternalPooledConnectionProvider;
-  private readonly config;
-  private readonly poolConfig;
+  private readonly config: AwsMySQLClientConfig;
+  private readonly poolConfig?: AwsPoolConfig;
 
-  constructor(config: any, poolConfig?: AwsPoolConfig) {
+  constructor(config: AwsMySQLClientConfig, poolConfig?: AwsPoolConfig) {
     this.connectionProvider = new InternalPooledConnectionProvider(poolConfig);
     this.config = config;
     this.poolConfig = poolConfig;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "debug-integration": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --inspect-brk=0.0.0.0:5005\" npx jest --config=jest.integration.config.json --runInBand",
     "lint": "eslint --ext .ts .",
     "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest --config=jest.unit.config.json",
-    "fix-imports": "babel --extensions \".js\" dist -d dist",
+    "fix-imports": "babel --extensions \".js\" dist -d dist && node scripts/fix-dts-imports.mjs",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf --preserve-root dist",
@@ -66,14 +66,19 @@
     "@babel/cli": "^7.29.7",
     "@babel/core": "^7.29.7",
     "@babel/node": "^7.29.7",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/context-async-hooks": "^2.7.1",
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.218.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.218.0",
     "@opentelemetry/id-generator-aws-xray": "^2.1.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.73.0",
     "@opentelemetry/instrumentation-http": "^0.218.0",
     "@opentelemetry/propagator-aws-xray": "^2.2.0",
+    "@opentelemetry/resources": "^2.7.1",
     "@opentelemetry/sdk-metrics": "^2.7.1",
     "@opentelemetry/sdk-node": "^0.218.0",
+    "@opentelemetry/sdk-trace-base": "^2.7.1",
+    "@opentelemetry/semantic-conventions": "^1.41.1",
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.24",
     "@types/node": "^22.10.7",
@@ -96,6 +101,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "generate-license-file": "^4.2.1",
     "globals": "^16.5.0",
+    "http-cookie-agent": "^6.0.8",
     "jest-html-reporter": "^4.4.0",
     "lint-staged": "^16.4.0",
     "mysql2": "^3.22.3",
@@ -104,6 +110,7 @@
     "prettier": "^3.8.3",
     "querystring": "^0.2.1",
     "rimraf": "^6.1.3",
+    "tough-cookie": "^5.1.2",
     "toxiproxy-node-client": "^4.1.0",
     "ts-jest": "^29.4.11",
     "ts-mockito": "^2.6.1",
@@ -113,14 +120,8 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/context-async-hooks": "^2.7.1",
-    "@opentelemetry/resources": "^2.7.1",
-    "@opentelemetry/sdk-trace-base": "^2.7.1",
-    "@opentelemetry/semantic-conventions": "^1.41.1",
     "async-mutex": "^0.5.0",
     "dotenv": "^16.6.1",
-    "http-cookie-agent": "^6.0.8",
     "winston": "^3.19.0"
   },
   "peerDependencies": {
@@ -130,6 +131,7 @@
     "@aws-sdk/client-xray": "^3.1053.0",
     "@aws-sdk/credential-providers": "^3.1053.0",
     "@aws-sdk/rds-signer": "^3.1053.0",
+    "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.218.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.218.0",
     "@opentelemetry/id-generator-aws-xray": "^2.1.0",
@@ -138,13 +140,16 @@
     "@opentelemetry/propagator-aws-xray": "^2.2.0",
     "@opentelemetry/sdk-metrics": "^2.7.1",
     "@opentelemetry/sdk-node": "^0.218.0",
+    "@smithy/types": "^4.14.2",
     "aws-xray-sdk": "^3.12.0",
     "axios": "^1.18.1",
     "axios-cookiejar-support": "^6.0.5",
     "entities": "^6.0.0",
+    "http-cookie-agent": "^6.0.8",
     "mysql2": "^3.22.3",
     "node-fetch": "^3.3.2",
-    "pg": "^8.21.0"
+    "pg": "^8.21.0",
+    "tough-cookie": "^5.1.2"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-rds": {
@@ -163,6 +168,9 @@
       "optional": true
     },
     "@aws-sdk/rds-signer": {
+      "optional": true
+    },
+    "@opentelemetry/api": {
       "optional": true
     },
     "@opentelemetry/exporter-metrics-otlp-grpc": {
@@ -189,6 +197,9 @@
     "@opentelemetry/sdk-node": {
       "optional": true
     },
+    "@smithy/types": {
+      "optional": true
+    },
     "aws-xray-sdk": {
       "optional": true
     },
@@ -201,6 +212,9 @@
     "entities": {
       "optional": true
     },
+    "http-cookie-agent": {
+      "optional": true
+    },
     "mysql2": {
       "optional": true
     },
@@ -208,6 +222,9 @@
       "optional": true
     },
     "pg": {
+      "optional": true
+    },
+    "tough-cookie": {
       "optional": true
     }
   },

--- a/pg.ts
+++ b/pg.ts
@@ -15,4 +15,5 @@
 */
 
 export { AwsPGClient, AwsPgPoolClient } from "./pg/lib/index";
-export type { AwsPGPooledConnection } from "./pg/lib/index";
+export type { AwsPGPooledConnection, AwsPgClientConfig } from "./pg/lib/index";
+export type { AwsClientConfig } from "./common/lib/wrapper_property";

--- a/pg.ts
+++ b/pg.ts
@@ -17,3 +17,4 @@
 export { AwsPGClient, AwsPgPoolClient } from "./pg/lib/index";
 export type { AwsPGPooledConnection, AwsPgClientConfig } from "./pg/lib/index";
 export type { AwsClientConfig } from "./common/lib/wrapper_property";
+export type { AwsCredentialsProviderHandler } from "./common/lib/authentication/aws_credentials_manager";

--- a/pg/lib/client.ts
+++ b/pg/lib/client.ts
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import { QueryArrayConfig, QueryArrayResult, QueryConfig, QueryConfigValues, QueryResult, QueryResultRow, Submittable } from "pg";
+import { ClientConfig, QueryArrayConfig, QueryArrayResult, QueryConfig, QueryConfigValues, QueryResult, QueryResultRow, Submittable } from "pg";
 import { AwsClient } from "../../common/lib/aws_client";
 import { PgConnectionUrlParser } from "./pg_connection_url_parser";
 import { DatabaseDialect, DatabaseType } from "../../common/lib/database_dialect/database_dialect";
@@ -42,6 +42,9 @@ import { isDialectTopologyAware } from "../../common/lib/database_dialect/topolo
 import { PGClient, PGPoolClient } from "./pg_client";
 import { DriverConnectionProvider } from "../../common/lib/driver_connection_provider";
 import { GlobalAuroraPgDatabaseDialect } from "./dialect/global_aurora_pg_database_dialect";
+import { AwsClientConfig } from "../../common/lib/wrapper_property";
+
+export interface AwsPgClientConfig extends ClientConfig, AwsClientConfig {}
 
 class BaseAwsPgClient extends AwsClient implements PGClient {
   private static readonly knownDialectsByCode: Map<string, DatabaseDialect> = new Map([
@@ -52,7 +55,7 @@ class BaseAwsPgClient extends AwsClient implements PGClient {
     [DatabaseDialectCodes.RDS_MULTI_AZ_PG, new RdsMultiAZClusterPgDatabaseDialect()]
   ]);
 
-  constructor(config: any, connectionProvider?: ConnectionProvider) {
+  constructor(config: AwsPgClientConfig, connectionProvider?: ConnectionProvider) {
     super(
       config,
       DatabaseType.POSTGRES,
@@ -336,13 +339,13 @@ class BaseAwsPgClient extends AwsClient implements PGClient {
 }
 
 export class AwsPGClient extends BaseAwsPgClient {
-  constructor(config: any) {
+  constructor(config: AwsPgClientConfig) {
     super(config, new DriverConnectionProvider());
   }
 }
 
 class AwsPGPooledConnection extends BaseAwsPgClient {
-  constructor(config: any, provider: ConnectionProvider) {
+  constructor(config: AwsPgClientConfig, provider: ConnectionProvider) {
     super(config, provider);
   }
 
@@ -367,10 +370,10 @@ export type { AwsPGPooledConnection };
 
 export class AwsPgPoolClient implements PGPoolClient {
   private readonly connectionProvider: InternalPooledConnectionProvider;
-  private readonly config;
-  private readonly poolConfig;
+  private readonly config: AwsPgClientConfig;
+  private readonly poolConfig?: AwsPoolConfig;
 
-  constructor(config: any, poolConfig?: AwsPoolConfig) {
+  constructor(config: AwsPgClientConfig, poolConfig?: AwsPoolConfig) {
     this.connectionProvider = new InternalPooledConnectionProvider(poolConfig);
     this.config = config;
     this.poolConfig = poolConfig;

--- a/scripts/fix-dts-imports.mjs
+++ b/scripts/fix-dts-imports.mjs
@@ -1,0 +1,86 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Appends explicit ".js" (or "/index.js" for directory imports) to relative
+// module specifiers in the emitted declaration files, so the published types
+// resolve correctly under Node's "node16"/"nodenext" module resolution. The
+// sibling ".js" outputs already receive this treatment from the babel step;
+// declaration files are not processed by babel, so they are rewritten here
+// using the same filesystem-based resolution.
+
+import { readdirSync, readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolve the dist directory relative to this script (scripts/../dist), so the
+// step works regardless of the current working directory.
+const DIST = resolve(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+
+function* declarationFiles(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* declarationFiles(full);
+    } else if (entry.name.endsWith(".d.ts")) {
+      yield full;
+    }
+  }
+}
+
+// Mirrors babel-plugin-transform-rewrite-imports: relative file -> "<spec>.js",
+// relative directory -> "<spec>/index.js". Bare specifiers are left untouched.
+function rewriteSpecifier(fileDir, spec) {
+  if (/\.(js|json|mjs|cjs)$/.test(spec)) {
+    return spec;
+  }
+  const target = resolve(fileDir, spec);
+  if (existsSync(`${target}.d.ts`)) {
+    return `${spec.replace(/\/+$/, "")}.js`;
+  }
+  if (existsSync(join(target, "index.d.ts")) || (existsSync(target) && statSync(target).isDirectory())) {
+    return `${spec.replace(/\/+$/, "")}/index.js`;
+  }
+  return `${spec.replace(/\/+$/, "")}.js`;
+}
+
+const SPECIFIER_PATTERNS = [
+  /(\bfrom\s*["'])(\.[^"']*)(["'])/g, // import/export ... from "..."
+  /(\bimport\(\s*["'])(\.[^"']*)(["'])/g // dynamic import() type references
+];
+
+let changedFiles = 0;
+let changedSpecifiers = 0;
+
+for (const file of declarationFiles(DIST)) {
+  const fileDir = dirname(file);
+  const original = readFileSync(file, "utf8");
+  let updated = original;
+  for (const pattern of SPECIFIER_PATTERNS) {
+    updated = updated.replace(pattern, (_match, lead, spec, trail) => {
+      const next = rewriteSpecifier(fileDir, spec);
+      if (next !== spec) {
+        changedSpecifiers++;
+      }
+      return `${lead}${next}${trail}`;
+    });
+  }
+  if (updated !== original) {
+    writeFileSync(file, updated);
+    changedFiles++;
+  }
+}
+
+console.log(`fix-dts-imports: rewrote ${changedSpecifiers} specifier(s) across ${changedFiles} declaration file(s).`);

--- a/tests/unit/aws_client_config.test.ts
+++ b/tests/unit/aws_client_config.test.ts
@@ -1,0 +1,87 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import * as ts from "typescript";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { AwsClientConfig, WrapperProperties, WrapperProperty } from "../../common/lib/wrapper_property";
+import { AwsMySQLClientConfig } from "../../mysql/lib/client";
+import { AwsPgClientConfig } from "../../pg/lib/client";
+
+// Standard connection properties supplied by the underlying driver config types
+// (`ConnectionOptions` for mysql2, `ClientConfig` for pg), which the driver-specific
+// configs inherit. They are intentionally NOT re-declared on `AwsClientConfig`.
+const DRIVER_PROVIDED = new Set(["host", "user", "password", "port", "database"]);
+
+// Extract the property names declared on a TypeScript interface, by parsing the
+// source file's AST. `AwsClientConfig` is a compile-time-only type, so it cannot
+// be introspected at runtime — this reads the actual declaration instead.
+function interfacePropertyNames(sourceRelativePath: string, interfaceName: string): string[] {
+  const source = readFileSync(join(process.cwd(), sourceRelativePath), "utf8");
+  const sourceFile = ts.createSourceFile(sourceRelativePath, source, ts.ScriptTarget.Latest, true);
+  const names: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === interfaceName) {
+      for (const member of node.members) {
+        if (ts.isPropertySignature(member) && member.name && ts.isIdentifier(member.name)) {
+          names.push(member.name.text);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return names;
+}
+
+// The configuration key each WrapperProperty maps to is its `.name` (the first
+// constructor argument), enumerated from the static members at runtime.
+function wrapperPropertyNames(): string[] {
+  return Object.values(WrapperProperties)
+    .filter((value): value is WrapperProperty<any> => value instanceof WrapperProperty)
+    .map((property) => property.name);
+}
+
+describe("AwsClientConfig stays in sync with WrapperProperties", () => {
+  const configKeys = new Set(interfacePropertyNames("common/lib/wrapper_property.ts", "AwsClientConfig"));
+  const propertyNames = wrapperPropertyNames();
+
+  it("finds interface keys and wrapper properties (sanity check)", () => {
+    expect(configKeys.size).toBeGreaterThan(0);
+    expect(propertyNames.length).toBeGreaterThan(0);
+  });
+
+  it("declares every WrapperProperty on AwsClientConfig (or inherits it from the driver config)", () => {
+    // If this fails, add the listed option(s) to the AwsClientConfig interface in
+    // common/lib/wrapper_property.ts so TypeScript consumers can set them.
+    const missing = propertyNames.filter((name) => !configKeys.has(name) && !DRIVER_PROVIDED.has(name)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  it("has no AwsClientConfig key without a matching WrapperProperty (no stale/renamed options)", () => {
+    // If this fails, an AwsClientConfig key no longer matches a WrapperProperty
+    // name — fix the typo or remove the obsolete option.
+    const propertyNameSet = new Set(propertyNames);
+    const stale = [...configKeys].filter((key) => !propertyNameSet.has(key)).sort();
+    expect(stale).toEqual([]);
+  });
+
+  it("keeps the driver-specific configs assignable to AwsClientConfig (compile-time)", () => {
+    const asBaseConfig = (config: AwsClientConfig): AwsClientConfig => config;
+    expect(asBaseConfig({} as AwsMySQLClientConfig)).toBeDefined();
+    expect(asBaseConfig({} as AwsPgClientConfig)).toBeDefined();
+  });
+});


### PR DESCRIPTION
### Summary

Add TypeScript configuration types for the AWS clients, correct the packaged runtime dependencies, and fix declaration-file resolution.

### Description
**Configuration types**

- Add an `AwsClientConfig` interface (`common/lib/wrapper_property.ts`) covering the wrapper's configuration options, kept in parity with `WrapperProperties`.
- Add driver-specific `AwsMySQLClientConfig` (`extends ConnectionOptions, AwsClientConfig`) and `AwsPgClientConfig` (`extends ClientConfig, AwsClientConfig`), and type the client constructors with them instead of `any`.
- Export `AwsClientConfig`, `AwsMySQLClientConfig`, and `AwsPgClientConfig` from the `./mysql` and `./pg` entry points so consumers can annotate their configs.

**Declaration-file resolution**

- The emitted `.d.ts` files used extensionless relative imports, which are invalid under `node16`/`nodenext` (and silently degrade the types to `any` under `skipLibCheck`). Add a post-build step (`scripts/fix-dts-imports.mjs`, wired into `fix-imports`) that appends `.js`/`/index.js` to relative specifiers in declaration files, mirroring the existing Babel step for `.js` output.

**Runtime / peer dependencies**

- Correct the OpenTelemetry and AWS SDK dependency declarations and add the federated-auth runtime dependencies (`tough-cookie` + `@types/tough-cookie`,  `http-cookie-agent`) so bundlers no longer fail to resolve them.
- Update the Federated Auth and Okta Auth plugin docs to list the required packages accurately.

**Type correctness**

- `SessionStateClient.getTransactionIsolation()` now returns `TransactionIsolationLevel | undefined`, matching `AwsClient` and the implementations (previously surfaced as a `TS2416` for consumers using `skipLibCheck: false`).

**Compatibility notes**

- For TypeScript consumers, `config` is now a closed interface, so inline configuration literals are subject to excess-property checks; the interface is kept in full parity with the supported wrapper properties. JavaScript consumers are unaffected (types are erased; runtime behavior is unchanged).
- Verified via a packed tarball installed into a clean strict/ESM project: the  `./mysql` and `./pg` types resolve and enforce correctly under `bundler`, `node16`, and `nodenext` (with `skipLibCheck` on and off).

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
