### PR TITLE
chore: removing `any` from external facing API

### DIFF
--- a/common/lib/aws_client.ts
+++ b/common/lib/aws_client.ts
@@ -25,7 +25,7 @@ import { ClientWrapper } from "./client_wrapper";
 import { DefaultTelemetryFactory } from "./utils/telemetry/default_telemetry_factory";
 import { TelemetryFactory } from "./utils/telemetry/telemetry_factory";
 import { DriverDialect } from "./driver_dialect/driver_dialect";
-import { WrapperProperties } from "./wrapper_property";
+import { AwsClientConfig, WrapperProperties } from "./wrapper_property";
 import { DriverConfigurationProfiles } from "./profile/driver_configuration_profiles";
 import { ConfigurationProfile } from "./profile/configuration_profile";
 import { AwsWrapperError, ConnectionProvider, TransactionIsolationLevel } from "./";
@@ -54,11 +54,11 @@ export abstract class AwsClient extends EventEmitter implements SessionStateClie
   protected _connectionUrlParser: ConnectionUrlParser;
   protected _configurationProfile: ConfigurationProfile | null = null;
   readonly properties: Map<string, any>;
-  config: any;
+  config: AwsClientConfig;
   targetClient?: ClientWrapper;
 
   protected constructor(
-    config: any,
+    config: AwsClientConfig,
     dbType: DatabaseType,
     knownDialectsByCode: Map<string, DatabaseDialect>,
     parser: ConnectionUrlParser,
@@ -166,31 +166,31 @@ export abstract class AwsClient extends EventEmitter implements SessionStateClie
     return this._connectionUrlParser;
   }
 
-  abstract setReadOnly(readOnly: boolean): Promise<any | void>;
+  abstract setReadOnly(readOnly: boolean): Promise<unknown>;
 
   abstract isReadOnly(): boolean | undefined;
 
-  abstract setAutoCommit(autoCommit: boolean): Promise<any | void>;
+  abstract setAutoCommit(autoCommit: boolean): Promise<unknown>;
 
   abstract getAutoCommit(): boolean | undefined;
 
-  abstract setTransactionIsolation(level: TransactionIsolationLevel): Promise<any | void>;
+  abstract setTransactionIsolation(level: TransactionIsolationLevel): Promise<unknown>;
 
   abstract getTransactionIsolation(): TransactionIsolationLevel | undefined;
 
-  abstract setSchema(schema: any): Promise<any | void>;
+  abstract setSchema(schema: string): Promise<unknown>;
 
   abstract getSchema(): string | undefined;
 
-  abstract setCatalog(catalog: string): Promise<any | void>;
+  abstract setCatalog(catalog: string): Promise<unknown>;
 
   abstract getCatalog(): string | undefined;
 
-  abstract end(): Promise<any>;
+  abstract end(): Promise<unknown>;
 
-  abstract connect(): Promise<any>;
+  abstract connect(): Promise<void>;
 
-  abstract rollback(): Promise<any>;
+  abstract rollback(): Promise<unknown>;
 
   unwrapPlugin<T>(iface: new (...args: any[]) => T): T | null {
     return this.pluginManager.unwrapPlugin(iface);
@@ -203,7 +203,7 @@ export abstract class AwsClient extends EventEmitter implements SessionStateClie
     return await this.pluginService.isClientValid(this.targetClient);
   }
 
-  getPluginInstance<T>(iface: any): T {
+  getPluginInstance<T>(iface: new (...args: any[]) => T): T {
     return this.pluginManager.getPluginInstance(iface);
   }
 }

--- a/common/lib/connection_plugin.ts
+++ b/common/lib/connection_plugin.ts
@@ -39,7 +39,7 @@ export interface ConnectionPlugin {
     forceConnectFunc: () => Promise<ClientWrapper>
   ): Promise<ClientWrapper>;
 
-  execute<T>(methodName: string, methodFunc: () => Promise<T>, methodArgs: any): Promise<T>;
+  execute<T>(methodName: string, methodFunc: () => Promise<T>, methodArgs: any[]): Promise<T>;
 
   initHostProvider(
     hostInfo: HostInfo,

--- a/common/lib/driver_dialect/driver_dialect.ts
+++ b/common/lib/driver_dialect/driver_dialect.ts
@@ -24,15 +24,15 @@ export interface DriverDialect {
 
   connect(hostInfo: HostInfo, props: Map<string, any>): Promise<ClientWrapper>;
 
-  preparePoolClientProperties(props: Map<string, any>, poolConfig: AwsPoolConfig | undefined): any;
+  preparePoolClientProperties(props: Map<string, any>, poolConfig: AwsPoolConfig | undefined): unknown;
 
-  getAwsPoolClient(props: any): AwsInternalPoolClient;
+  getAwsPoolClient(props: unknown): AwsInternalPoolClient;
 
-  setConnectTimeout(props: Map<string, any>, wrapperConnectTimeout?: any): void;
+  setConnectTimeout(props: Map<string, any>, wrapperConnectTimeout?: number): void;
 
-  setQueryTimeout(props: Map<string, any>, sql?: any, wrapperQueryTimeout?: any): void;
+  setQueryTimeout(props: Map<string, any>, sql?: unknown, wrapperQueryTimeout?: number): void;
 
-  setKeepAliveProperties(props: Map<string, any>, keepAliveProps: any): void;
+  setKeepAliveProperties(props: Map<string, any>, keepAliveProps: unknown): void;
 
-  getQueryFromMethodArg(methodArg: any): string;
+  getQueryFromMethodArg(methodArg: unknown): string;
 }

--- a/common/lib/plugin_manager.ts
+++ b/common/lib/plugin_manager.ts
@@ -410,7 +410,7 @@ export class PluginManager {
     return this.telemetryFactory;
   }
 
-  getPluginInstance<T>(iface: any): T {
+  getPluginInstance<T>(iface: new (...args: any[]) => T): T {
     for (const p of this._plugins) {
       if (p instanceof iface) {
         return p as T;

--- a/common/lib/session_state_client.ts
+++ b/common/lib/session_state_client.ts
@@ -17,23 +17,23 @@
 import { TransactionIsolationLevel } from "./utils/transaction_isolation_level";
 
 export interface SessionStateClient {
-  setReadOnly(readOnly: boolean): Promise<any | void>;
+  setReadOnly(readOnly: boolean): Promise<unknown>;
 
   isReadOnly(): boolean | undefined;
 
-  setAutoCommit(autoCommit: boolean): Promise<any | void>;
+  setAutoCommit(autoCommit: boolean): Promise<unknown>;
 
   getAutoCommit(): boolean | undefined;
 
-  setTransactionIsolation(level: TransactionIsolationLevel): Promise<any | void>;
+  setTransactionIsolation(level: TransactionIsolationLevel): Promise<unknown>;
 
   getTransactionIsolation(): TransactionIsolationLevel | undefined;
 
-  setSchema(schema: any): Promise<any | void>;
+  setSchema(schema: string): Promise<unknown>;
 
   getSchema(): string | undefined;
 
-  setCatalog(catalog: string): Promise<any | void>;
+  setCatalog(catalog: string): Promise<unknown>;
 
   getCatalog(): string | undefined;
 }

--- a/mysql/lib/client.ts
+++ b/mysql/lib/client.ts
@@ -15,7 +15,7 @@
 */
 
 import { AwsClient } from "../../common/lib/aws_client";
-import { ErrorPacketParams, OkPacketParams, Query, QueryOptions, QueryResult } from "mysql2";
+import { ErrorPacketParams, FieldPacket, OkPacketParams, Query, QueryOptions, QueryResult } from "mysql2";
 import { ConnectionOptions, Prepare, PrepareStatementInfo } from "mysql2/promise";
 import { MySQLConnectionUrlParser } from "./mysql_connection_url_parser";
 import { DatabaseDialect, DatabaseType } from "../../common/lib/database_dialect/database_dialect";
@@ -510,10 +510,10 @@ class BaseAwsMySQLClient extends AwsClient implements MySQLClient {
     );
   }
 
-  query<T extends QueryResult>(sql: string): Promise<[T, any]>;
-  query<T extends QueryResult>(sql: string, values: any): Promise<[T, any]>;
-  query<T extends QueryResult>(options: QueryOptions): Promise<[T, any]>;
-  query<T extends QueryResult>(options: QueryOptions, values: any): Promise<[T, any]>;
+  query<T extends QueryResult>(sql: string): Promise<[T, FieldPacket[]]>;
+  query<T extends QueryResult>(sql: string, values: any): Promise<[T, FieldPacket[]]>;
+  query<T extends QueryResult>(options: QueryOptions): Promise<[T, FieldPacket[]]>;
+  query<T extends QueryResult>(options: QueryOptions, values: any): Promise<[T, FieldPacket[]]>;
   async query(options: string | QueryOptions, values?: any): Promise<[any, any]> {
     if (!this.isConnected) {
       await this.connect(); // client.connect is not required for MySQL clients
@@ -540,9 +540,9 @@ class BaseAwsMySQLClient extends AwsClient implements MySQLClient {
     });
   }
 
-  execute<T extends QueryResult>(sql: string): Promise<[T, any]>;
-  execute<T extends QueryResult>(sql: string, values: any): Promise<[T, any]>;
-  execute<T extends QueryResult>(options: QueryOptions): Promise<[T, any]>;
+  execute<T extends QueryResult>(sql: string): Promise<[T, FieldPacket[]]>;
+  execute<T extends QueryResult>(sql: string, values: any): Promise<[T, FieldPacket[]]>;
+  execute<T extends QueryResult>(options: QueryOptions): Promise<[T, FieldPacket[]]>;
   async execute(options: string | QueryOptions, values?: any): Promise<[any, any]> {
     if (!this.isConnected) {
       await this.connect(); // client.connect is not required for MySQL clients
@@ -635,10 +635,10 @@ export class AwsMySQLPoolClient implements MySQLPoolClient {
     return connection.end();
   }
 
-  query<T extends QueryResult>(sql: string): Promise<[T, any]>;
-  query<T extends QueryResult>(sql: string, values: any): Promise<[T, any]>;
-  query<T extends QueryResult>(options: QueryOptions): Promise<[T, any]>;
-  query<T extends QueryResult>(options: QueryOptions, values: any): Promise<[T, any]>;
+  query<T extends QueryResult>(sql: string): Promise<[T, FieldPacket[]]>;
+  query<T extends QueryResult>(sql: string, values: any): Promise<[T, FieldPacket[]]>;
+  query<T extends QueryResult>(options: QueryOptions): Promise<[T, FieldPacket[]]>;
+  query<T extends QueryResult>(options: QueryOptions, values: any): Promise<[T, FieldPacket[]]>;
   async query(options: string | QueryOptions, values?: any): Promise<[any, any]> {
     const awsMySQLPooledConnection: AwsMySQLPooledConnection = new AwsMySQLPooledConnection(this.config, this.connectionProvider);
     try {

--- a/mysql/lib/mysql_client.ts
+++ b/mysql/lib/mysql_client.ts
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import { ErrorPacketParams, OkPacketParams, QueryOptions, QueryResult } from "mysql2";
+import { ErrorPacketParams, FieldPacket, OkPacketParams, QueryOptions, QueryResult } from "mysql2";
 import { ConnectionOptions, Prepare, PrepareStatementInfo } from "mysql2/promise";
 import { AwsMySQLPooledConnection } from "./client";
 
@@ -68,23 +68,23 @@ export interface MySQLClient {
 
   writePacket(packet: any): Promise<void>;
 
-  query<T extends QueryResult>(sql: string): Promise<[T, any]>;
+  query<T extends QueryResult>(sql: string): Promise<[T, FieldPacket[]]>;
 
-  query<T extends QueryResult>(sql: string, values: any): Promise<[T, any]>;
+  query<T extends QueryResult>(sql: string, values: any): Promise<[T, FieldPacket[]]>;
 
-  query<T extends QueryResult>(options: QueryOptions): Promise<[T, any]>;
+  query<T extends QueryResult>(options: QueryOptions): Promise<[T, FieldPacket[]]>;
 
-  query<T extends QueryResult>(options: QueryOptions, values: any): Promise<[T, any]>;
+  query<T extends QueryResult>(options: QueryOptions, values: any): Promise<[T, FieldPacket[]]>;
 
-  query<T extends QueryResult>(options: string | QueryOptions, values: any): Promise<[T, any]>;
+  query<T extends QueryResult>(options: string | QueryOptions, values: any): Promise<[T, FieldPacket[]]>;
 
-  execute<T extends QueryResult>(sql: string): Promise<[T, any]>;
+  execute<T extends QueryResult>(sql: string): Promise<[T, FieldPacket[]]>;
 
-  execute<T extends QueryResult>(sql: string, values: any): Promise<[T, any]>;
+  execute<T extends QueryResult>(sql: string, values: any): Promise<[T, FieldPacket[]]>;
 
-  execute<T extends QueryResult>(options: QueryOptions): Promise<[T, any]>;
+  execute<T extends QueryResult>(options: QueryOptions): Promise<[T, FieldPacket[]]>;
 
-  execute<T extends QueryResult>(options: string | QueryOptions, values: any): Promise<[T, any]>;
+  execute<T extends QueryResult>(options: string | QueryOptions, values: any): Promise<[T, FieldPacket[]]>;
 }
 
 export interface MySQLPoolClient {
@@ -94,13 +94,13 @@ export interface MySQLPoolClient {
 
   end(): Promise<void>;
 
-  query<T extends QueryResult>(sql: string): Promise<[T, any]>;
+  query<T extends QueryResult>(sql: string): Promise<[T, FieldPacket[]]>;
 
-  query<T extends QueryResult>(sql: string, values: any): Promise<[T, any]>;
+  query<T extends QueryResult>(sql: string, values: any): Promise<[T, FieldPacket[]]>;
 
-  query<T extends QueryResult>(options: QueryOptions): Promise<[T, any]>;
+  query<T extends QueryResult>(options: QueryOptions): Promise<[T, FieldPacket[]]>;
 
-  query<T extends QueryResult>(options: QueryOptions, values: any): Promise<[T, any]>;
+  query<T extends QueryResult>(options: QueryOptions, values: any): Promise<[T, FieldPacket[]]>;
 
-  query<T extends QueryResult>(options: string | QueryOptions, values: any): Promise<[T, any]>;
+  query<T extends QueryResult>(options: string | QueryOptions, values: any): Promise<[T, FieldPacket[]]>;
 }

--- a/pg/lib/client.ts
+++ b/pg/lib/client.ts
@@ -227,9 +227,9 @@ class BaseAwsPgClient extends AwsClient implements PGClient {
     });
   }
 
-  query(text: string): Promise<any>;
+  query(text: string): Promise<QueryResult>;
 
-  query(text: string, values: any[]): Promise<any>;
+  query(text: string, values: any[]): Promise<QueryResult>;
 
   query<T extends Submittable>(queryStream: T): T;
 
@@ -389,9 +389,9 @@ export class AwsPgPoolClient implements PGPoolClient {
     await this.connectionProvider.releaseResources();
   }
 
-  query(text: string): Promise<any>;
+  query(text: string): Promise<QueryResult>;
 
-  query(text: string, values: any[]): Promise<any>;
+  query(text: string, values: any[]): Promise<QueryResult>;
 
   query<T extends Submittable>(queryStream: T): T;
 

--- a/pg/lib/pg_client.ts
+++ b/pg/lib/pg_client.ts
@@ -22,9 +22,9 @@ export interface PGClient {
 
   end(): Promise<void>;
 
-  query(text: string): Promise<any>;
+  query(text: string): Promise<QueryResult>;
 
-  query(text: string, values: any[]): Promise<any>;
+  query(text: string, values: any[]): Promise<QueryResult>;
 
   query<T extends Submittable>(queryStream: T): T;
 
@@ -61,7 +61,7 @@ export interface PGPoolClient {
 
   query<R extends QueryResultRow = any, I = any[]>(queryConfig: QueryConfig<I>): Promise<QueryResult<R>>;
 
-  query(text: string): Promise<any>;
+  query(text: string): Promise<QueryResult>;
 
-  query(text: string, values: any[]): Promise<any>;
+  query(text: string, values: any[]): Promise<QueryResult>;
 }


### PR DESCRIPTION
### Summary

Remove `any` from the wrapper's external-facing (public) API. Type-only changes — no runtime behavior change.

### Description

Follow-up to #687. That PR typed client construction; this one covers the remaining `any` that reaches consumers through the public type surfaces such as the query/result methods. Internal `any` such as the `Map<string, any>` connection properties is intentionally left unchanged.

**Client query/result surface**

- pg: the string-form `query(...)` overloads now return `Promise<QueryResult>` instead of `Promise<any>` (`PGClient`, `PGPoolClient`, and the client impls).
- mysql: `query` / `execute` now return `Promise<[T, FieldPacket[]]>` instead of `Promise<[T, any]>` (`MySQLClient`, `MySQLPoolClient`, and the client impls).

**Client base class**

- `config` is now typed `AwsClientConfig` instead of `any`.
- `setSchema(schema: any)` → `setSchema(schema: string)`.
- Setters and `end`/`rollback` return `Promise<unknown>` (was `Promise<any | void>` / `Promise<any>`); `connect()` returns `Promise<void>`.
- `getPluginInstance(iface: any)` → `getPluginInstance(iface: new (...args: any[]) => T)`.

**Exported extension interfaces**

- `DriverDialect`: `getAwsPoolClient`, `preparePoolClientProperties` (return), `getQueryFromMethodArg`, and `setKeepAliveProperties` use `unknown`; `wrapperConnectTimeout` / `wrapperQueryTimeout` use `number`; `sql` uses `unknown`.
- `ConnectionPlugin.execute`: `methodArgs: any` → `methodArgs: any[]`.
- The concrete (non-exported) implementation classes keep their existing signatures — they satisfy the stricter interfaces via TypeScript's method bivariance / return covariance, so there is no implementation churn.

**Intentionally left as `any`**

- `props: Map<string, any>` (the properties bag) stays `any`: it is a heterogeneous dynamic map, narrowing gives normal users no benefit, and changing it to `unknown` would be a breaking change for existing plugin authors. Consumers who read a config value get the typed result through `WrapperProperties.<X>.get(...)`.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
